### PR TITLE
Add 'hiding' to reservedMeta in Haskell.bnf and regenerate files.

### DIFF
--- a/gen/com/haskforce/parser/HaskellParser.java
+++ b/gen/com/haskforce/parser/HaskellParser.java
@@ -607,6 +607,7 @@ public class HaskellParser implements PsiParser {
 
   /* ********************************************************** */
   // 'as' | 'import' | 'infix' | 'infixl' | 'infixr' | 'qualified'
+  //                | 'hiding'
   public static boolean reservedMeta(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "reservedMeta")) return false;
     boolean result_ = false;
@@ -617,6 +618,7 @@ public class HaskellParser implements PsiParser {
     if (!result_) result_ = consumeToken(builder_, "infixl");
     if (!result_) result_ = consumeToken(builder_, "infixr");
     if (!result_) result_ = consumeToken(builder_, "qualified");
+    if (!result_) result_ = consumeToken(builder_, "hiding");
     exit_section_(builder_, level_, marker_, RESERVED_META, result_, false, null);
     return result_;
   }

--- a/gen/com/haskforce/psi/HaskellConsym.java
+++ b/gen/com/haskforce/psi/HaskellConsym.java
@@ -10,4 +10,7 @@ public interface HaskellConsym extends PsiElement {
   @NotNull
   List<HaskellSymbol> getSymbolList();
 
+  @NotNull
+  PsiElement getColon();
+
 }

--- a/gen/com/haskforce/psi/HaskellReservedDecl.java
+++ b/gen/com/haskforce/psi/HaskellReservedDecl.java
@@ -7,4 +7,7 @@ import com.intellij.psi.PsiElement;
 
 public interface HaskellReservedDecl extends PsiElement {
 
+  @Nullable
+  PsiElement getClasstoken();
+
 }

--- a/gen/com/haskforce/psi/HaskellReservedop.java
+++ b/gen/com/haskforce/psi/HaskellReservedop.java
@@ -10,4 +10,7 @@ public interface HaskellReservedop extends PsiElement {
   @Nullable
   HaskellReservedopWithoutCons getReservedopWithoutCons();
 
+  @Nullable
+  PsiElement getColon();
+
 }

--- a/gen/com/haskforce/psi/HaskellReservedopWithoutCons.java
+++ b/gen/com/haskforce/psi/HaskellReservedopWithoutCons.java
@@ -7,4 +7,34 @@ import com.intellij.psi.PsiElement;
 
 public interface HaskellReservedopWithoutCons extends PsiElement {
 
+  @Nullable
+  PsiElement getAmpersat();
+
+  @Nullable
+  PsiElement getBackslash();
+
+  @Nullable
+  PsiElement getDoublearrow();
+
+  @Nullable
+  PsiElement getDoublecolon();
+
+  @Nullable
+  PsiElement getDoubleperiod();
+
+  @Nullable
+  PsiElement getEquals();
+
+  @Nullable
+  PsiElement getLeftarrow();
+
+  @Nullable
+  PsiElement getPipe();
+
+  @Nullable
+  PsiElement getRightarrow();
+
+  @Nullable
+  PsiElement getTilde();
+
 }

--- a/gen/com/haskforce/psi/HaskellSpecial.java
+++ b/gen/com/haskforce/psi/HaskellSpecial.java
@@ -7,4 +7,28 @@ import com.intellij.psi.PsiElement;
 
 public interface HaskellSpecial extends PsiElement {
 
+  @Nullable
+  PsiElement getComma();
+
+  @Nullable
+  PsiElement getLbrace();
+
+  @Nullable
+  PsiElement getLbracket();
+
+  @Nullable
+  PsiElement getLparen();
+
+  @Nullable
+  PsiElement getRbrace();
+
+  @Nullable
+  PsiElement getRbracket();
+
+  @Nullable
+  PsiElement getRparen();
+
+  @Nullable
+  PsiElement getSemicolon();
+
 }

--- a/gen/com/haskforce/psi/HaskellSymbol.java
+++ b/gen/com/haskforce/psi/HaskellSymbol.java
@@ -7,4 +7,64 @@ import com.intellij.psi.PsiElement;
 
 public interface HaskellSymbol extends PsiElement {
 
+  @Nullable
+  PsiElement getAmpersand();
+
+  @Nullable
+  PsiElement getAmpersat();
+
+  @Nullable
+  PsiElement getAsterisk();
+
+  @Nullable
+  PsiElement getBackslash();
+
+  @Nullable
+  PsiElement getCaret();
+
+  @Nullable
+  PsiElement getColon();
+
+  @Nullable
+  PsiElement getDollar();
+
+  @Nullable
+  PsiElement getEquals();
+
+  @Nullable
+  PsiElement getExlamation();
+
+  @Nullable
+  PsiElement getGreaterthan();
+
+  @Nullable
+  PsiElement getHash();
+
+  @Nullable
+  PsiElement getLessthan();
+
+  @Nullable
+  PsiElement getMinus();
+
+  @Nullable
+  PsiElement getPercent();
+
+  @Nullable
+  PsiElement getPeriod();
+
+  @Nullable
+  PsiElement getPipe();
+
+  @Nullable
+  PsiElement getPlus();
+
+  @Nullable
+  PsiElement getQuestion();
+
+  @Nullable
+  PsiElement getSlash();
+
+  @Nullable
+  PsiElement getTilde();
+
 }

--- a/gen/com/haskforce/psi/HaskellVarid.java
+++ b/gen/com/haskforce/psi/HaskellVarid.java
@@ -7,4 +7,7 @@ import com.intellij.psi.PsiElement;
 
 public interface HaskellVarid extends PsiElement {
 
+  @NotNull
+  PsiElement getVaridRegexp();
+
 }

--- a/gen/com/haskforce/psi/impl/HaskellConsymImpl.java
+++ b/gen/com/haskforce/psi/impl/HaskellConsymImpl.java
@@ -28,4 +28,10 @@ public class HaskellConsymImpl extends ASTWrapperPsiElement implements HaskellCo
     return PsiTreeUtil.getChildrenOfTypeAsList(this, HaskellSymbol.class);
   }
 
+  @Override
+  @NotNull
+  public PsiElement getColon() {
+    return findNotNullChildByType(COLON);
+  }
+
 }

--- a/gen/com/haskforce/psi/impl/HaskellReservedDeclImpl.java
+++ b/gen/com/haskforce/psi/impl/HaskellReservedDeclImpl.java
@@ -22,4 +22,10 @@ public class HaskellReservedDeclImpl extends ASTWrapperPsiElement implements Has
     else super.accept(visitor);
   }
 
+  @Override
+  @Nullable
+  public PsiElement getClasstoken() {
+    return findChildByType(CLASSTOKEN);
+  }
+
 }

--- a/gen/com/haskforce/psi/impl/HaskellReservedopImpl.java
+++ b/gen/com/haskforce/psi/impl/HaskellReservedopImpl.java
@@ -28,4 +28,10 @@ public class HaskellReservedopImpl extends ASTWrapperPsiElement implements Haske
     return findChildByClass(HaskellReservedopWithoutCons.class);
   }
 
+  @Override
+  @Nullable
+  public PsiElement getColon() {
+    return findChildByType(COLON);
+  }
+
 }

--- a/gen/com/haskforce/psi/impl/HaskellReservedopWithoutConsImpl.java
+++ b/gen/com/haskforce/psi/impl/HaskellReservedopWithoutConsImpl.java
@@ -22,4 +22,64 @@ public class HaskellReservedopWithoutConsImpl extends ASTWrapperPsiElement imple
     else super.accept(visitor);
   }
 
+  @Override
+  @Nullable
+  public PsiElement getAmpersat() {
+    return findChildByType(AMPERSAT);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getBackslash() {
+    return findChildByType(BACKSLASH);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getDoublearrow() {
+    return findChildByType(DOUBLEARROW);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getDoublecolon() {
+    return findChildByType(DOUBLECOLON);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getDoubleperiod() {
+    return findChildByType(DOUBLEPERIOD);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getEquals() {
+    return findChildByType(EQUALS);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getLeftarrow() {
+    return findChildByType(LEFTARROW);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getPipe() {
+    return findChildByType(PIPE);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getRightarrow() {
+    return findChildByType(RIGHTARROW);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getTilde() {
+    return findChildByType(TILDE);
+  }
+
 }

--- a/gen/com/haskforce/psi/impl/HaskellSpecialImpl.java
+++ b/gen/com/haskforce/psi/impl/HaskellSpecialImpl.java
@@ -22,4 +22,52 @@ public class HaskellSpecialImpl extends ASTWrapperPsiElement implements HaskellS
     else super.accept(visitor);
   }
 
+  @Override
+  @Nullable
+  public PsiElement getComma() {
+    return findChildByType(COMMA);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getLbrace() {
+    return findChildByType(LBRACE);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getLbracket() {
+    return findChildByType(LBRACKET);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getLparen() {
+    return findChildByType(LPAREN);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getRbrace() {
+    return findChildByType(RBRACE);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getRbracket() {
+    return findChildByType(RBRACKET);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getRparen() {
+    return findChildByType(RPAREN);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getSemicolon() {
+    return findChildByType(SEMICOLON);
+  }
+
 }

--- a/gen/com/haskforce/psi/impl/HaskellSymbolImpl.java
+++ b/gen/com/haskforce/psi/impl/HaskellSymbolImpl.java
@@ -22,4 +22,124 @@ public class HaskellSymbolImpl extends ASTWrapperPsiElement implements HaskellSy
     else super.accept(visitor);
   }
 
+  @Override
+  @Nullable
+  public PsiElement getAmpersand() {
+    return findChildByType(AMPERSAND);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getAmpersat() {
+    return findChildByType(AMPERSAT);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getAsterisk() {
+    return findChildByType(ASTERISK);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getBackslash() {
+    return findChildByType(BACKSLASH);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getCaret() {
+    return findChildByType(CARET);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getColon() {
+    return findChildByType(COLON);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getDollar() {
+    return findChildByType(DOLLAR);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getEquals() {
+    return findChildByType(EQUALS);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getExlamation() {
+    return findChildByType(EXLAMATION);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getGreaterthan() {
+    return findChildByType(GREATERTHAN);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getHash() {
+    return findChildByType(HASH);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getLessthan() {
+    return findChildByType(LESSTHAN);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getMinus() {
+    return findChildByType(MINUS);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getPercent() {
+    return findChildByType(PERCENT);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getPeriod() {
+    return findChildByType(PERIOD);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getPipe() {
+    return findChildByType(PIPE);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getPlus() {
+    return findChildByType(PLUS);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getQuestion() {
+    return findChildByType(QUESTION);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getSlash() {
+    return findChildByType(SLASH);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getTilde() {
+    return findChildByType(TILDE);
+  }
+
 }

--- a/gen/com/haskforce/psi/impl/HaskellVaridImpl.java
+++ b/gen/com/haskforce/psi/impl/HaskellVaridImpl.java
@@ -22,4 +22,10 @@ public class HaskellVaridImpl extends ASTWrapperPsiElement implements HaskellVar
     else super.accept(visitor);
   }
 
+  @Override
+  @NotNull
+  public PsiElement getVaridRegexp() {
+    return findNotNullChildByType(VARIDREGEXP);
+  }
+
 }

--- a/src/com/haskforce/Haskell.bnf
+++ b/src/com/haskforce/Haskell.bnf
@@ -119,6 +119,7 @@ reservedExpr ::= 'case' | 'do' | 'else' | 'if' | 'in' | 'let' | 'of' | 'then'
 reservedDecl ::= 'class' | 'data' | 'default' | 'deriving' | 'foreign' | 'instance'
                | 'module' | 'newtype' | 'type' | 'where'
 reservedMeta ::= 'as' | 'import' | 'infix' | 'infixl' | 'infixr' | 'qualified'
+               | 'hiding'
 reservedVar ::= '_'
 reservedid  ::= reservedExpr | reservedDecl | reservedMeta | reservedVar
 

--- a/tests/gold/parser/Import1.txt
+++ b/tests/gold/parser/Import1.txt
@@ -19,10 +19,8 @@ Haskell File
     HaskellModulePrefixImpl(MODULE_PREFIX)
       <empty list>
     PsiElement(HaskellTokenType.conid)('Prelude')
-  HaskellQvaridImpl(QVARID)
-    HaskellModulePrefixImpl(MODULE_PREFIX)
-      <empty list>
-    HaskellVaridImpl(VARID)
+  HaskellReservedidImpl(RESERVEDID)
+    HaskellReservedMetaImpl(RESERVED_META)
       PsiElement(HaskellTokenType.varidRegexp)('hiding')
   HaskellSpecialImpl(SPECIAL)
     PsiElement(HaskellTokenType.()('(')


### PR DESCRIPTION
Imports hiding things are currently not highlighted in the 'hiding' part of the import statement. The keyword exists in a later chapter in the standard:

http://www.haskell.org/onlinereport/haskell2010/haskellch10.html#x17-17700010.2

How do you feel about adding support for parsing GHC extensions in general?
