### PR TITLE
Fix for #135.

### DIFF
--- a/src/com/haskforce/highlighting/annotation/HaskellDocumentationProvider.java
+++ b/src/com/haskforce/highlighting/annotation/HaskellDocumentationProvider.java
@@ -2,8 +2,14 @@ package com.haskforce.highlighting.annotation;
 
 import com.haskforce.highlighting.annotation.external.TypeInfoUtil;
 import com.intellij.lang.documentation.AbstractDocumentationProvider;
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.VisualPosition;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
@@ -17,8 +23,24 @@ import org.jetbrains.annotations.Nullable;
 public class HaskellDocumentationProvider extends AbstractDocumentationProvider {
     @Override
     public String generateDoc(PsiElement element, @Nullable PsiElement originalElement) {
+        int startOffset = element.getTextRange().getStartOffset();
+        int endOffset = element.getTextRange().getEndOffset();
         Project project = element.getProject();
-        return TypeInfoUtil.getTypeInfo(project);
+        FileDocumentManager fileDocumentManager= FileDocumentManager.getInstance();
+        VirtualFile projectFile = element.getContainingFile().getVirtualFile();
+        Document cachedDocument = fileDocumentManager.getCachedDocument(projectFile);
+        if (cachedDocument == null) {
+            return null;
+        }
+        int startLineNumber = cachedDocument.getLineNumber(startOffset);
+        int endLineNumber = cachedDocument.getLineNumber(endOffset);
+        int startColumn = startOffset - cachedDocument.getLineStartOffset(startLineNumber);
+        int endColumn = endOffset - cachedDocument.getLineStartOffset(endLineNumber);
+
+        // and also correct them for (0,0) vs (1,1) leftmost coordinate (intellij -> ghc)
+        VisualPosition startPosition = TypeInfoUtil.correctFor0BasedVS1Based(new VisualPosition(startLineNumber, startColumn));
+        VisualPosition endPosition = TypeInfoUtil.correctFor0BasedVS1Based(new VisualPosition(endLineNumber, endColumn));
+        return TypeInfoUtil.getTypeInfo(project,startPosition,endPosition, projectFile);
     }
 
 }

--- a/src/com/haskforce/highlighting/annotation/external/TypeInfoUtil.java
+++ b/src/com/haskforce/highlighting/annotation/external/TypeInfoUtil.java
@@ -29,10 +29,6 @@ public class TypeInfoUtil {
         if (fileEditorManager == null){
             return null;
         }
-        /**
-         * This call always generates a rather large stacktrace,when called from  but succeeds nevertheless.
-         * No clue why right now, but best find out.
-         */
         Editor textEditor = fileEditorManager.getSelectedTextEditor();
         if (textEditor == null){
             return null;
@@ -52,11 +48,15 @@ public class TypeInfoUtil {
         if (projectFile == null){
             return "project file is null";
         }
+
+        return getTypeInfo(project, blockStart, blockEnd, projectFile);
+    }
+
+    public static String getTypeInfo(Project project, VisualPosition blockStart, VisualPosition blockEnd, VirtualFile projectFile) {
         final String canonicalPath = projectFile.getCanonicalPath();
         if (canonicalPath == null){
             return "canonical path is null";
         }
-
         final String workDir = ExecUtil.guessWorkDir(project, projectFile);
         if (ToolKey.GHC_MODI_KEY.getPath(project) != null) {
             final Module module = ModuleUtilCore.findModuleForFile(projectFile, project);
@@ -67,17 +67,17 @@ public class TypeInfoUtil {
                             blockStart,blockEnd));
 
                 } else {
-                    return "ghcModi == null";
+                    return "ghcModi is not configured";
                 }
             } else {
-                return "module == null";
+                return "didn't find module";
             }
         } else {
             return GhcMod.type(project, workDir, canonicalPath, blockStart, blockEnd);
         }
     }
 
-    private static VisualPosition correctFor0BasedVS1Based(VisualPosition pos0Based) {
+    public static VisualPosition correctFor0BasedVS1Based(VisualPosition pos0Based) {
         if (pos0Based == null){
             return null;
         }


### PR DESCRIPTION
After some discussion on the intellij forums, it seemed that it wasn't a good plan to use the Editor in the documentation provider. The way to go was using the psi element supplied to find the correct line and column number. Tried to keep the reuse of code as big as possible.