### PR TITLE
Support finding of definitions in exported modules

### DIFF
--- a/src/com/haskforce/codeInsight/HaskellLineMarkerProvider.java
+++ b/src/com/haskforce/codeInsight/HaskellLineMarkerProvider.java
@@ -28,8 +28,12 @@ public class HaskellLineMarkerProvider extends RelatedItemLineMarkerProvider {
             String value = namedElement.getName();
             if (value != null) {
                 Project project = element.getProject();
-                final List<PsiNamedElement> namedNodes =
+                final List<HaskellUtil.FoundDefinition> found =
                         HaskellUtil.findDefinitionNode(project, value, namedElement);
+                final List<PsiNamedElement> namedNodes = ContainerUtil.newArrayList();
+                for (HaskellUtil.FoundDefinition fd : found) {
+                    namedNodes.add(fd.element);
+                }
 
                 if (namedNodes.size() > 0) {
                     NavigationGutterIconBuilder<PsiElement> builder =

--- a/src/com/haskforce/psi/HaskellPsiUtil.java
+++ b/src/com/haskforce/psi/HaskellPsiUtil.java
@@ -71,10 +71,8 @@ public class HaskellPsiUtil {
             final HaskellQconid moduleQconid = qconids.get(0);
             final String module = moduleQconid.getText();
             final String alias = numQconids > 1 ? qconids.get(1).getText() : null;
-            final PsiElement maybeQualified = PsiTreeUtil.prevVisibleLeaf(moduleQconid);
-            final boolean isQualified = maybeQualified != null && isType(maybeQualified, HaskellTypes.QUALIFIED);
-            final PsiElement maybeHiding = PsiTreeUtil.nextVisibleLeaf(moduleQconid);
-            final boolean isHiding = maybeHiding != null && isType(maybeHiding, HaskellTypes.HIDING);
+            final boolean isQualified = impdecl.getQualified() != null;
+            final boolean isHiding = impdecl.getHiding() != null;
             final String[] explicitNames;
             // Check if we have an empty import list.
             if (impdecl.getImpempty() != null) {

--- a/src/com/haskforce/utils/HaskellUtil.java
+++ b/src/com/haskforce/utils/HaskellUtil.java
@@ -83,6 +83,7 @@ public class HaskellUtil {
                 if (hidden || notImported) continue;
                 for (HaskellFile f2 : HaskellModuleIndex.getFilesByModuleName(project, imprt.module, GlobalSearchScope.allScope(project))) {
                     findDefinitionNode(f2, name, e, result);
+                    findDefinitionNodeInExport(project, f2, name, e, result);
                 }
             }
         }

--- a/src/com/haskforce/utils/HaskellUtil.java
+++ b/src/com/haskforce/utils/HaskellUtil.java
@@ -74,18 +74,15 @@ public class HaskellUtil {
                                                    @Nullable PsiNamedElement e, List<PsiNamedElement> result) {
         List<HaskellPsiUtil.Import> imports = HaskellPsiUtil.parseImports(f);
         for (HaskellExport export : PsiTreeUtil.findChildrenOfType(f, HaskellExport.class)) {
-            if (export.getModuletoken() == null) continue;
-            for (HaskellConid exportCon : PsiTreeUtil.findChildrenOfType(export, HaskellConid.class)) {
-                String exportName = exportCon.getName();
-                if (exportName == null) continue;
-                for (HaskellPsiUtil.Import imprt : imports) {
-                    if (!exportName.equals(imprt.module) && !exportName.equals(imprt.alias)) continue;
-                    boolean hidden = imprt.getHidingNames() != null && ArrayUtil.contains(name, imprt.getHidingNames());
-                    boolean notImported = imprt.getImportedNames() != null && !ArrayUtil.contains(name, imprt.getImportedNames());
-                    if (hidden || notImported) continue;
-                    for (HaskellFile f2 : HaskellModuleIndex.getFilesByModuleName(project, imprt.module, GlobalSearchScope.allScope(project))) {
-                        findDefinitionNode(f2, name, e, result);
-                    }
+            if (export.getModuletoken() == null || export.getQconid() == null) continue;
+            String exportName = export.getQconid().getText();
+            for (HaskellPsiUtil.Import imprt : imports) {
+                if (!exportName.equals(imprt.module) && !exportName.equals(imprt.alias)) continue;
+                boolean hidden = imprt.getHidingNames() != null && ArrayUtil.contains(name, imprt.getHidingNames());
+                boolean notImported = imprt.getImportedNames() != null && !ArrayUtil.contains(name, imprt.getImportedNames());
+                if (hidden || notImported) continue;
+                for (HaskellFile f2 : HaskellModuleIndex.getFilesByModuleName(project, imprt.module, GlobalSearchScope.allScope(project))) {
+                    findDefinitionNode(f2, name, e, result);
                 }
             }
         }

--- a/src/com/haskforce/utils/HaskellUtil.java
+++ b/src/com/haskforce/utils/HaskellUtil.java
@@ -26,16 +26,15 @@ public class HaskellUtil {
      * definitions are found when name is null.
      */
     @NotNull
-    public static List<PsiNamedElement> findDefinitionNode(@NotNull Project project, @Nullable String name, @Nullable PsiNamedElement e) {
+    public static List<PsiNamedElement> findDefinitionNode(@NotNull Project project, @Nullable String name, @NotNull PsiNamedElement e) {
         // Guess where the name could be defined by lookup up potential modules.
         final Set<String> potentialModules =
-                e == null ? Collections.EMPTY_SET
-                        : getPotentialDefinitionModuleNames(e, HaskellPsiUtil.parseImports(e.getContainingFile()));
+                getPotentialDefinitionModuleNames(e, HaskellPsiUtil.parseImports(e.getContainingFile()));
         List<PsiNamedElement> result = ContainerUtil.newArrayList();
-        final String qPrefix = e == null ? null : getQualifiedPrefix(e);
-        final PsiFile psiFile = e == null ? null : e.getContainingFile().getOriginalFile();
+        final String qPrefix = getQualifiedPrefix(e);
+        final PsiFile psiFile = e.getContainingFile().getOriginalFile();
         if (psiFile instanceof HaskellFile) {
-            findDefinitionNode((HaskellFile)psiFile, name, e, result);
+            findDefinitionNode((HaskellFile) psiFile, name, e, result);
         }
         for (String potentialModule : potentialModules) {
             List<HaskellFile> files = HaskellModuleIndex.getFilesByModuleName(project, potentialModule, GlobalSearchScope.allScope(project));
@@ -86,22 +85,11 @@ public class HaskellUtil {
     }
 
     /**
-     * Finds name definition across all Haskell files in the project. All
-     * definitions are found when name is null.
-     */
-    @NotNull
-    public static List<PsiNamedElement> findDefinitionNodes(@NotNull Project project) {
-        return findDefinitionNode(project, null, null);
-    }
-
-    /**
      * Finds name definitions that are within the scope of a file, including imports (to some degree).
      */
     @NotNull
     public static List<PsiNamedElement> findDefinitionNodes(@NotNull HaskellFile psiFile) {
-        List<PsiNamedElement> result = findDefinitionNodes(psiFile, null);
-        result.addAll(findDefinitionNode(psiFile.getProject(), null, null));
-        return result;
+        return findDefinitionNodes(psiFile, null);
     }
 
     /**

--- a/tests/com/haskforce/resolve/HaskellResolveTest.java
+++ b/tests/com/haskforce/resolve/HaskellResolveTest.java
@@ -13,6 +13,7 @@ public class HaskellResolveTest extends HaskellResolveTestCase {
     public void testData00003() { doTest(false); }
     public void testData00004() { doTest(false); }
     public void testData00005() { doTest(false); }
+    public void testData00006() { doTest(false); }
     public void testFunctionWithoutSignature00001() { doTest(); }
     public void testFunctionWithoutSignature00002() { doTest(); }
     public void testFunctionWithSignature00001() { doTest(); }

--- a/tests/com/haskforce/resolve/HaskellResolveTest.java
+++ b/tests/com/haskforce/resolve/HaskellResolveTest.java
@@ -18,4 +18,8 @@ public class HaskellResolveTest extends HaskellResolveTestCase {
     public void testFunctionWithoutSignature00002() { doTest(); }
     public void testFunctionWithSignature00001() { doTest(); }
     public void testNewtype00001() { doTest(); }
+    public void testModule00001() { doTest(); }
+    public void testModule00002() { doTest(); }
+    public void testModule00003() { doTest(); }
+    public void testModule00004() { doTest(); }
 }

--- a/tests/gold/resolve/Data00006/Bar.hs
+++ b/tests/gold/resolve/Data00006/Bar.hs
@@ -1,0 +1,5 @@
+module Bar where
+
+import qualified Foo.Foo as Barry
+
+mkFoo = <ref>Foo "yo!"

--- a/tests/gold/resolve/Data00006/Baz.hs
+++ b/tests/gold/resolve/Data00006/Baz.hs
@@ -1,0 +1,3 @@
+module Baz where
+
+data Baz = Foo | Bar

--- a/tests/gold/resolve/Data00006/Foo.hs
+++ b/tests/gold/resolve/Data00006/Foo.hs
@@ -1,0 +1,3 @@
+module Foo.Foo where
+
+data Foo a = <resolved>Foo a | Bar a deriving (Show)

--- a/tests/gold/resolve/Module00001/Bar.hs
+++ b/tests/gold/resolve/Module00001/Bar.hs
@@ -1,0 +1,5 @@
+module Bar where
+
+import Baz
+
+mkFoo = <ref>foo

--- a/tests/gold/resolve/Module00001/Baz.hs
+++ b/tests/gold/resolve/Module00001/Baz.hs
@@ -1,0 +1,8 @@
+module Baz (
+    module Foo
+  , abc
+  ) where
+
+import Foo
+
+abc = "xyz"

--- a/tests/gold/resolve/Module00001/Baz.hs
+++ b/tests/gold/resolve/Module00001/Baz.hs
@@ -1,8 +1,8 @@
 module Baz (
-    module Foo
+    module Foo.Foo
   , abc
   ) where
 
-import Foo
+import Foo.Foo
 
 abc = "xyz"

--- a/tests/gold/resolve/Module00001/Foo.hs
+++ b/tests/gold/resolve/Module00001/Foo.hs
@@ -1,3 +1,3 @@
-module Foo where
+module Foo.Foo where
 
 <resolved>foo = putStrLn "oh no!"

--- a/tests/gold/resolve/Module00001/Foo.hs
+++ b/tests/gold/resolve/Module00001/Foo.hs
@@ -1,0 +1,3 @@
+module Foo where
+
+<resolved>foo = putStrLn "oh no!"

--- a/tests/gold/resolve/Module00002/Bam.hs
+++ b/tests/gold/resolve/Module00002/Bam.hs
@@ -1,0 +1,5 @@
+module Bam (
+    module X
+  ) where
+
+import Foo as X

--- a/tests/gold/resolve/Module00002/Bar.hs
+++ b/tests/gold/resolve/Module00002/Bar.hs
@@ -1,0 +1,5 @@
+module Bar where
+
+import Baz
+
+mkFoo = <ref>foo

--- a/tests/gold/resolve/Module00002/Baz.hs
+++ b/tests/gold/resolve/Module00002/Baz.hs
@@ -1,0 +1,5 @@
+module Baz (
+    module X
+  ) where
+
+import Foo as X

--- a/tests/gold/resolve/Module00002/Baz.hs
+++ b/tests/gold/resolve/Module00002/Baz.hs
@@ -2,4 +2,4 @@ module Baz (
     module X
   ) where
 
-import Foo as X
+import Bam as X

--- a/tests/gold/resolve/Module00002/Foo.hs
+++ b/tests/gold/resolve/Module00002/Foo.hs
@@ -1,0 +1,3 @@
+module Foo where
+
+<resolved>foo = putStrLn "oh no!"

--- a/tests/gold/resolve/Module00003/Bar.hs
+++ b/tests/gold/resolve/Module00003/Bar.hs
@@ -1,0 +1,5 @@
+module Bar where
+
+import Baz
+
+mkFoo = <ref>foo

--- a/tests/gold/resolve/Module00003/Baz.hs
+++ b/tests/gold/resolve/Module00003/Baz.hs
@@ -1,0 +1,6 @@
+module Baz (
+    module X
+  ) where
+
+import Ignore as X
+import Foo as X

--- a/tests/gold/resolve/Module00003/Foo.hs
+++ b/tests/gold/resolve/Module00003/Foo.hs
@@ -1,0 +1,3 @@
+module Foo where
+
+<resolved>foo = putStrLn "oh no!"

--- a/tests/gold/resolve/Module00003/Ignore.hs
+++ b/tests/gold/resolve/Module00003/Ignore.hs
@@ -1,0 +1,1 @@
+module Ignore where

--- a/tests/gold/resolve/Module00004/Bar.hs
+++ b/tests/gold/resolve/Module00004/Bar.hs
@@ -1,0 +1,5 @@
+module Bar where
+
+import Baz
+
+mkFoo = <ref>foo

--- a/tests/gold/resolve/Module00004/Baz.hs
+++ b/tests/gold/resolve/Module00004/Baz.hs
@@ -1,0 +1,8 @@
+module Baz (
+    module X
+  , module Foo
+  ) where
+
+import Hiding as X hiding (foo)
+import Qualified as X (foo2)
+import Foo

--- a/tests/gold/resolve/Module00004/Foo.hs
+++ b/tests/gold/resolve/Module00004/Foo.hs
@@ -1,0 +1,3 @@
+module Foo where
+
+<resolved>foo = putStrLn "oh no!"

--- a/tests/gold/resolve/Module00004/Hiding.hs
+++ b/tests/gold/resolve/Module00004/Hiding.hs
@@ -1,0 +1,3 @@
+module Hiding where
+
+foo = putStrLn "oh no!"

--- a/tests/gold/resolve/Module00004/Qualified.hs
+++ b/tests/gold/resolve/Module00004/Qualified.hs
@@ -1,0 +1,5 @@
+module Qualified where
+
+foo = putStrLn "oh no!"
+
+foo2 = putStrLn "oh no!"


### PR DESCRIPTION
This supports finding declarations that are exported as a module, something that our projects do all the time:

```haskell
module TopLevel (module X) where
import Foo as X
import Bar as X
```

I suspect this might not play nicely with https://github.com/carymrobbins/intellij-haskforce/issues/86. I'm happy to make whatever tweaks you deem necessary if you're not comfortable with my changes.

I have tried to isolate some small refactors into their own commits, some of which might be worth merging as separate PRs if you find them useful and this PR is too risky.