### PR TITLE
Jump to data/type/newtype definitions

### DIFF
--- a/src/com/haskforce/utils/HaskellUtil.java
+++ b/src/com/haskforce/utils/HaskellUtil.java
@@ -70,8 +70,23 @@ public class HaskellUtil {
         for (PsiNamedElement namedElement : namedElements) {
             if ((name == null || name.equals(namedElement.getName())) && definitionNode(namedElement)) {
                 result.add(namedElement);
+            } else if (name != null && name.equals(namedElement.getName()) && typeNode(name, namedElement)) {
+                result.add(namedElement);
             }
         }
+    }
+
+    private static boolean typeNode(@NotNull String name, @NotNull PsiNamedElement e) {
+        HaskellDatadecl datadecl = PsiTreeUtil.getParentOfType(e, HaskellDatadecl.class);
+        if (datadecl != null) {
+            return datadecl.getTypeeList().get(0).getAtypeList().get(0).getText().equals(name);
+        }
+        HaskellNewtypedecl newtypedecl = PsiTreeUtil.getParentOfType(e, HaskellNewtypedecl.class);
+        if (newtypedecl != null && newtypedecl.getTycon() != null) {
+            return name.equals(newtypedecl.getTycon().getConid().getName());
+        }
+        HaskellTypedecl typedecl = PsiTreeUtil.getParentOfType(e, HaskellTypedecl.class);
+        return typedecl != null && name.equals(typedecl.getTypeeList().get(0).getAtypeList().get(0).getText());
     }
 
     /**

--- a/src/com/haskforce/utils/HaskellUtil.java
+++ b/src/com/haskforce/utils/HaskellUtil.java
@@ -66,11 +66,12 @@ public class HaskellUtil {
         } else {
             elementClass = PsiNamedElement.class;
         }
+        final boolean isType = PsiTreeUtil.getParentOfType(e, HaskellGendecl.class) != null;
         Collection<PsiNamedElement> namedElements = PsiTreeUtil.findChildrenOfType(file, elementClass);
         for (PsiNamedElement namedElement : namedElements) {
             if ((name == null || name.equals(namedElement.getName())) && definitionNode(namedElement)) {
                 result.add(namedElement);
-            } else if (name != null && name.equals(namedElement.getName()) && typeNode(name, namedElement)) {
+            } else if (isType && name != null && name.equals(namedElement.getName()) && typeNode(name, namedElement)) {
                 result.add(namedElement);
             }
         }

--- a/src/com/haskforce/utils/HaskellUtil.java
+++ b/src/com/haskforce/utils/HaskellUtil.java
@@ -87,7 +87,21 @@ public class HaskellUtil {
             return name.equals(newtypedecl.getTycon().getConid().getName());
         }
         HaskellTypedecl typedecl = PsiTreeUtil.getParentOfType(e, HaskellTypedecl.class);
-        return typedecl != null && name.equals(typedecl.getTypeeList().get(0).getAtypeList().get(0).getText());
+        if (typedecl != null) {
+            return name.equals(typedecl.getTypeeList().get(0).getAtypeList().get(0).getText());
+        }
+        HaskellClassdecl classdecl = PsiTreeUtil.getParentOfType(e, HaskellClassdecl.class);
+        if (classdecl != null && classdecl.getCtype() != null) {
+            HaskellCtype ctype = classdecl.getCtype();
+            while (ctype.getCtype() != null) {
+                ctype = ctype.getCtype();
+            }
+            if (ctype.getTypee() == null) return false;
+            HaskellAtype haskellAtype = ctype.getTypee().getAtypeList().get(0);
+            return haskellAtype.getOqtycon() != null && haskellAtype.getOqtycon().getQtycon() != null &&
+                    name.equals(haskellAtype.getOqtycon().getQtycon().getTycon().getConid().getName());
+        }
+        return false;
     }
 
     /**

--- a/tests/com/haskforce/resolve/HaskellResolveTest.java
+++ b/tests/com/haskforce/resolve/HaskellResolveTest.java
@@ -8,6 +8,8 @@ package com.haskforce.resolve;
  *  - Insert "<resolved>" right before the element you wish for the reference to resolve to.
  */
 public class HaskellResolveTest extends HaskellResolveTestCase {
+    public void testClass00001() { doTest(); }
+    public void testClass00002() { doTest(); }
     public void testData00001() { doTest(); }
     public void testData00002() { doTest(false); }
     public void testData00003() { doTest(false); }

--- a/tests/com/haskforce/resolve/HaskellResolveTest.java
+++ b/tests/com/haskforce/resolve/HaskellResolveTest.java
@@ -13,8 +13,10 @@ public class HaskellResolveTest extends HaskellResolveTestCase {
     public void testData00003() { doTest(false); }
     public void testData00004() { doTest(false); }
     public void testData00005() { doTest(false); }
+    public void testData00007() { doTest(); }
     public void testFunctionWithoutSignature00001() { doTest(); }
     public void testFunctionWithoutSignature00002() { doTest(); }
     public void testFunctionWithSignature00001() { doTest(); }
     public void testNewtype00001() { doTest(); }
+    public void testType00001() { doTest(); }
 }

--- a/tests/gold/resolve/Class00001/Bar.hs
+++ b/tests/gold/resolve/Class00001/Bar.hs
@@ -1,0 +1,6 @@
+module Bar where
+
+import Foo
+
+mkFoo :: <ref>Foo a => a -> String
+mkFoo = bar

--- a/tests/gold/resolve/Class00001/Foo.hs
+++ b/tests/gold/resolve/Class00001/Foo.hs
@@ -1,0 +1,4 @@
+module Foo where
+
+class <resolved>Foo a where
+  baz :: a -> String

--- a/tests/gold/resolve/Class00002/Bar.hs
+++ b/tests/gold/resolve/Class00002/Bar.hs
@@ -1,0 +1,6 @@
+module Bar where
+
+import Foo
+
+mkFoo :: <ref>Foo a => a -> String
+mkFoo = bar

--- a/tests/gold/resolve/Class00002/Foo.hs
+++ b/tests/gold/resolve/Class00002/Foo.hs
@@ -1,0 +1,4 @@
+module Foo where
+
+class Monad a => <resolved>Foo a where
+  baz :: a -> String

--- a/tests/gold/resolve/Data00001/Foo.hs
+++ b/tests/gold/resolve/Data00001/Foo.hs
@@ -1,3 +1,3 @@
 module Foo where
 
-data Foo a = <resolved>Foo a | Bar a deriving (Show)
+data Foo2 a = <resolved>Foo a | Bar a deriving (Show)

--- a/tests/gold/resolve/Data00007/Bar.hs
+++ b/tests/gold/resolve/Data00007/Bar.hs
@@ -1,0 +1,6 @@
+module Bar where
+
+import Foo
+
+mkFoo :: <ref>Food String
+mkFoo = Foo1 "yo!"

--- a/tests/gold/resolve/Data00007/Foo.hs
+++ b/tests/gold/resolve/Data00007/Foo.hs
@@ -1,0 +1,3 @@
+module Foo where
+
+data <resolved>Food a = Foo1 a | Foo2 a deriving (Show)

--- a/tests/gold/resolve/Newtype00001/Foo.hs
+++ b/tests/gold/resolve/Newtype00001/Foo.hs
@@ -1,4 +1,4 @@
 module Foo where
 
-newtype Foo a = <resolved>Foo (a, a)
+newtype Foo2 a = <resolved>Foo (a, a)
 

--- a/tests/gold/resolve/Type00001/Bar.hs
+++ b/tests/gold/resolve/Type00001/Bar.hs
@@ -1,0 +1,6 @@
+module Bar where
+
+import Foo
+
+mkFoo :: <ref>Foo
+mkFoo = print "yo!"

--- a/tests/gold/resolve/Type00001/Foo.hs
+++ b/tests/gold/resolve/Type00001/Foo.hs
@@ -1,0 +1,3 @@
+module Foo where
+
+type <resolved>Foo = Bar


### PR DESCRIPTION
Apologies, this is more of a hack than the previous PR. Partly opening it to get feedback as to the correct/better approach.

This change creates the annoying problem that constructors that have the same name as the type will show up twice in the found list, rather than jumping to the constructor (which breaks two of the current tests). Jumping from a type signature will work fine - there's some handy filtering happening in `multiResolve()`.