### PR TITLE
Provide Configuration Type for Stack Run, similar to Cabal Run

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -254,6 +254,7 @@
       <externalAnnotator language="Haskell" implementationClass="com.haskforce.highlighting.annotation.external.HaskellExternalAnnotator"/>
       <configurationType implementation="com.haskforce.run.HaskellApplicationConfigurationType"/>
       <configurationType implementation="com.haskforce.run.HaskellTestConfigurationType"/>
+      <configurationType implementation="com.haskforce.run.stack.StackApplicationConfigurationType"/>
       <programRunner implementation="com.haskforce.run.HaskellRunner"/>
       <codeStyleSettingsProvider implementation="com.haskforce.language.formatting.HaskellCodeStyleSettingsProvider"/>
       <langCodeStyleSettingsProvider implementation="com.haskforce.language.formatting.HaskellLanguageCodeStyleSettingsProvider"/>

--- a/src/com/haskforce/run/stack/StackApplicationConfigurationType.scala
+++ b/src/com/haskforce/run/stack/StackApplicationConfigurationType.scala
@@ -1,0 +1,14 @@
+package com.haskforce.run.stack
+
+import com.haskforce.HaskellIcons
+import com.intellij.execution.configurations.{RunConfiguration, ConfigurationFactory, ConfigurationTypeBase}
+import com.intellij.openapi.project.Project
+
+class StackApplicationConfigurationType extends ConfigurationTypeBase("Stack Run Configuration", "Haskell Stack Run", "Execute a `stack exec` task.", HaskellIcons.FILE) {
+
+  addFactory(new ConfigurationFactory(this){
+    override def createTemplateConfiguration(project: Project): RunConfiguration = {
+      return new StackApplicationRunConfiguration(project, this)
+    }
+  })
+}

--- a/src/com/haskforce/run/stack/StackApplicationRunConfiguration.scala
+++ b/src/com/haskforce/run/stack/StackApplicationRunConfiguration.scala
@@ -1,0 +1,59 @@
+package com.haskforce.run.stack
+
+import java.util
+
+import com.intellij.execution.Executor
+import com.intellij.execution.configuration.AbstractRunConfiguration
+import com.intellij.execution.configurations.{RuntimeConfigurationException, RunProfileState, ConfigurationFactory}
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.components.PathMacroManager
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.JDOMExternalizerUtil
+import org.jdom.Element
+
+class StackApplicationRunConfiguration(project: Project, configFactory: ConfigurationFactory) extends
+  AbstractRunConfiguration(project, configFactory) {
+
+  val EXECUTABLE: String = "EXECUTABLE"
+  val EXECUTABLE_ARGUMENTS: String = "EXECUTABLE_ARGUMENTS"
+
+  var executable: String = null
+  var executableArguments: String = null
+
+  override def getValidModules: util.Collection[Module] = null
+
+  override def getConfigurationEditor: StackApplicationRunConfigurationEditorForm =
+    new StackApplicationRunConfigurationEditorForm
+
+  override def getState(executor: Executor, executionEnvironment: ExecutionEnvironment): RunProfileState = {
+    return new StackRunCommandLineState(executionEnvironment, this)
+  }
+
+  override def checkConfiguration(): Unit = {
+    if (!Option(executable).exists(_.trim.nonEmpty)) {
+      throw new RuntimeConfigurationException("Please specify an executable")
+    }
+  }
+  override def readExternal(element: Element): Unit = {
+    PathMacroManager.getInstance(getProject).expandPaths(element)
+    super.readExternal(element)
+    executable = JDOMExternalizerUtil.readField(element, EXECUTABLE)
+    executableArguments = JDOMExternalizerUtil.readField(element, EXECUTABLE_ARGUMENTS)
+  }
+
+  override def writeExternal(element: Element): Unit = {
+    super.writeExternal(element)
+    JDOMExternalizerUtil.writeField(element, EXECUTABLE, executable)
+    JDOMExternalizerUtil.writeField(element, EXECUTABLE_ARGUMENTS, executableArguments)
+    PathMacroManager.getInstance(getProject).collapsePathsRecursively(element)
+  }
+
+  def setExecutable(executable: String) {
+    this.executable = executable
+  }
+
+  def setExecutableArguments(executableArguments: String) {
+    this.executableArguments = executableArguments
+  }
+}

--- a/src/com/haskforce/run/stack/StackApplicationRunConfigurationEditorForm.form
+++ b/src/com/haskforce/run/stack/StackApplicationRunConfigurationEditorForm.form
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.haskforce.run.stack.StackApplicationRunConfigurationEditorForm">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="89342" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Executable Arguments:"/>
+        </properties>
+      </component>
+      <vspacer id="df9e8">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="a6502" class="com.intellij.ui.RawCommandLineEditor" binding="executableArguments">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="caaa4" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Executable:"/>
+        </properties>
+      </component>
+      <component id="f5f0d" class="com.intellij.ui.RawCommandLineEditor" binding="executable">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/src/com/haskforce/run/stack/StackApplicationRunConfigurationEditorForm.java
+++ b/src/com/haskforce/run/stack/StackApplicationRunConfigurationEditorForm.java
@@ -1,0 +1,35 @@
+package com.haskforce.run.stack;
+
+
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.ui.RawCommandLineEditor;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class StackApplicationRunConfigurationEditorForm extends SettingsEditor<StackApplicationRunConfiguration> {
+
+    private JPanel mainPanel;
+    private RawCommandLineEditor executable;
+    private RawCommandLineEditor executableArguments;
+
+
+    @NotNull
+    @Override
+    protected JComponent createEditor() {
+        return mainPanel;
+    }
+
+    @Override
+    protected void resetEditorFrom(StackApplicationRunConfiguration config) {
+        executable.setText(config.executable());
+        executableArguments.setText(config.executableArguments());
+    }
+
+    @Override
+    protected void applyEditorTo(StackApplicationRunConfiguration config) throws ConfigurationException {
+        config.setExecutable(executable.getText());
+        config.setExecutableArguments(executableArguments.getText());
+    }
+}

--- a/src/com/haskforce/run/stack/StackRunCommandLineState.scala
+++ b/src/com/haskforce/run/stack/StackRunCommandLineState.scala
@@ -1,0 +1,24 @@
+package com.haskforce.run.stack
+
+import com.haskforce.settings.HaskellBuildSettings
+import com.intellij.execution.configurations.{ParametersList, GeneralCommandLine, CommandLineState}
+import com.intellij.execution.process.{OSProcessHandler}
+import com.intellij.execution.runners.ExecutionEnvironment
+
+class StackRunCommandLineState(environment: ExecutionEnvironment,
+                               config: StackApplicationRunConfiguration) extends CommandLineState(environment) {
+
+  // run `stack exec <executable> -- <executableArguments>`
+  override def startProcess(): OSProcessHandler = {
+    val commandLine: GeneralCommandLine = new GeneralCommandLine
+    commandLine.setWorkDirectory(getEnvironment.getProject.getBasePath)
+    val buildSettings: HaskellBuildSettings = HaskellBuildSettings.getInstance(config.getProject)
+    commandLine.setExePath(buildSettings.getStackPath)
+    val parametersList: ParametersList = commandLine.getParametersList
+    parametersList.add("exec")
+    parametersList.add(config.executable)
+    parametersList.add("--")
+    parametersList.addParametersString(config.executableArguments)
+    return new OSProcessHandler(commandLine)
+  }
+}


### PR DESCRIPTION
Fixes #238

Minimal implementation to support "Stack run". It executes `stack exec <executable> -- <executable arguments>` where `executable` and `executable arguments` are configurable. 

Future work:
* validation/suggestion for executable names
* refactoring/renaming `HaskellApplicationConfiguration*` to `CabalHaskellApplicationConfiguration*`?
* implement `stack test` as a Configuration Type