### PR TITLE
fixed bug in HaskellCompilerConfigurable

### DIFF
--- a/src/com/haskforce/settings/HaskellCompilerConfigurable.java
+++ b/src/com/haskforce/settings/HaskellCompilerConfigurable.java
@@ -260,12 +260,12 @@ public class HaskellCompilerConfigurable extends CompilerConfigurable {
     }
 
     private void validateExecutable(String name, TextAccessor field) throws ConfigurationException {
-        if (new File(field.getText()).canExecute()) return;
+        if (new File(field.getText()).canExecute() || new File(myProject.getBasePath(), field.getText()).exists()) return;
         throw new ConfigurationException("Not a valid '" + name + "' executable: '" + field.getText() + "'");
     }
 
     private void validateFileExists(String name, TextAccessor field) throws ConfigurationException {
-        if (new File(field.getText()).exists()) return;
+        if (new File(field.getText()).exists() || new File(myProject.getBasePath(), field.getText()).exists()) return;
         throw new ConfigurationException("'" + name + "' file does not exist: '" + field.getText() + "'");
     }
 

--- a/tests/com/haskforce/highlighting/annotation/external/GhcModTest.scala
+++ b/tests/com/haskforce/highlighting/annotation/external/GhcModTest.scala
@@ -3,14 +3,13 @@ package com.haskforce.highlighting.annotation.external
 import java.util
 
 import scala.collection.JavaConverters._
-
 import junit.framework.TestCase
-
 import com.haskforce.HaskellLightPlatformCodeInsightFixtureTestCase
 import com.haskforce.highlighting.annotation.HaskellAnnotationHolder
 import com.haskforce.psi.impl.HaskellElementFactory
 import com.intellij.codeInsight.daemon.impl.AnnotationHolderImpl
 import com.intellij.lang.annotation.AnnotationSession
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.text.StringUtil
 
 /**
@@ -58,7 +57,9 @@ class GhcModTest extends HaskellLightPlatformCodeInsightFixtureTestCase("ghc-mod
                   "main ="
           ), "\n")
         )
-        file.setName("src/Main.hs")
+        ApplicationManager.getApplication.runWriteAction(new Runnable() {
+          def run() = file.setName("src/Main.hs")
+        })
 
         // Intentionally leaving both paths to /src/Main.hs the same to ensure that
         // createAnnotations sees both as the same file and handles the duplicate properly.


### PR DESCRIPTION
The default working-directory is the location of the intellij app, but stack.yml is located in the project base directory, so new File(name).exists() returned false even though stack.yaml was existing.

Also fixed a unit-test.