### PR TITLE
Improved syntax highlighting

### DIFF
--- a/src/com/haskforce/HaskellLanguage.java
+++ b/src/com/haskforce/HaskellLanguage.java
@@ -6,6 +6,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.util.containers.HashSet;
 
 import java.util.Arrays;
+import java.util.Set;
 
 import static com.haskforce.psi.HaskellTypes.*;
 
@@ -28,8 +29,22 @@ public class HaskellLanguage extends Language {
     /**
      * Tokens of bracket symbols.
      */
-    public static final HashSet<IElementType> BRACKET_TOKENS = new HashSet<IElementType>(
-            Arrays.asList(LPAREN, RPAREN, LBRACKET, RBRACKET, LBRACE, RBRACE, PARENSPLICE, LTHOPEN, RTHCLOSE, QQOPEN));
+    public static final HashSet<IElementType> BRACKET_TOKENS = new HashSet<>(
+            Arrays.asList(LBRACKET, RBRACKET, LTHOPEN, RTHCLOSE, QQOPEN));
+
+    /**
+     * Parens tokens
+     */
+    public static final Set<IElementType> PARENS_TOKENS = new HashSet<>(
+            Arrays.asList(LPAREN, RPAREN, PARENSPLICE)
+    );
+
+    /**
+     * Brace tokens
+     */
+    public static final Set<IElementType> BRACE_TOKENS = new HashSet<>(
+            Arrays.asList(LBRACE, RBRACE)
+    );
 
     /**
      * Tokens of reserved IDs.

--- a/src/com/haskforce/highlighting/HaskellAnnotator.java
+++ b/src/com/haskforce/highlighting/HaskellAnnotator.java
@@ -8,7 +8,6 @@ import com.intellij.lang.annotation.Annotator;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -46,6 +45,30 @@ public class HaskellAnnotator implements Annotator {
             public void visitQconsym(@NotNull HaskellQconsym o) {
                 super.visitQconsym(o);
                 setHighlighting(o, holder, HaskellSyntaxHighlighter.CONSYM);
+            }
+
+            /**
+             * Highlight the type signature as such.
+             */
+            @Override
+            public void visitGendecl(@NotNull HaskellGendecl o) {
+                super.visitGendecl(o);
+                HaskellVars vars = o.getVars();
+                if (vars != null) {
+                    vars.getVaridList().forEach(varid -> setHighlighting(varid, holder, HaskellSyntaxHighlighter.SIGNATURE));
+                }
+            }
+
+            /**
+             * Highlight function arguments as such.
+             */
+            @Override
+            public void visitFunorpatdecl(@NotNull HaskellFunorpatdecl o) {
+                super.visitFunorpatdecl(o);
+                o.getVaridList()
+                        .stream()
+                        .skip(1) //Skip first, as it is the name of the function.
+                        .forEach(varid -> setHighlighting(varid, holder, HaskellSyntaxHighlighter.PARAMETER));
             }
 
             @Override

--- a/src/com/haskforce/highlighting/HaskellSyntaxHighlighter.java
+++ b/src/com/haskforce/highlighting/HaskellSyntaxHighlighter.java
@@ -22,29 +22,57 @@ public class HaskellSyntaxHighlighter extends SyntaxHighlighterBase {
      * purposes.
      */
 
-    // TODO: Create text attributes specifically for Haskell - https://confluence.jetbrains.com/pages/viewpage.action?pageId=49463468
-    private static final TextAttributesKey JAVA_KEYWORD = TextAttributesKey.createTextAttributesKey("JAVA_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD);
-
-    public static final TextAttributesKey RESERVEDID = JAVA_KEYWORD;
-    public static final TextAttributesKey RESERVEDOP = JAVA_KEYWORD;
-    public static final TextAttributesKey COMMA = DefaultLanguageHighlighterColors.COMMA;
-    public static final TextAttributesKey SEMICOLON = DefaultLanguageHighlighterColors.SEMICOLON;
-    public static final TextAttributesKey BRACKETS = DefaultLanguageHighlighterColors.PARENTHESES;
-    public static final TextAttributesKey NCOMMENT = DefaultLanguageHighlighterColors.BLOCK_COMMENT;
-    public static final TextAttributesKey HADDOCK = DefaultLanguageHighlighterColors.DOC_COMMENT;
-    public static final TextAttributesKey COMMENT = DefaultLanguageHighlighterColors.LINE_COMMENT;
-    public static final TextAttributesKey INTEGER = DefaultLanguageHighlighterColors.NUMBER;
-    public static final TextAttributesKey FLOAT = DefaultLanguageHighlighterColors.NUMBER;
-    public static final TextAttributesKey CHAR = DefaultLanguageHighlighterColors.NUMBER;
-    public static final TextAttributesKey CONID = DefaultLanguageHighlighterColors.INSTANCE_FIELD;
-    public static final TextAttributesKey VARID = DefaultLanguageHighlighterColors.IDENTIFIER;
-    public static final TextAttributesKey INFIXVARID = DefaultLanguageHighlighterColors.INSTANCE_FIELD;
-    public static final TextAttributesKey VARSYM = DefaultLanguageHighlighterColors.IDENTIFIER;
-    public static final TextAttributesKey CONSYM = DefaultLanguageHighlighterColors.INSTANCE_FIELD;
-    public static final TextAttributesKey PRAGMA = DefaultLanguageHighlighterColors.METADATA;
-    public static final TextAttributesKey STRING = DefaultLanguageHighlighterColors.STRING;
-    public static final TextAttributesKey QQTEXT = DefaultLanguageHighlighterColors.STRING;
-    public static final TextAttributesKey ESCAPE = DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE;
+    /*
+     * We classify the reserved IDs as keywords.
+     */
+    public static final TextAttributesKey RESERVED_ID
+            = TextAttributesKey.createTextAttributesKey("HS_RESERVED_ID", DefaultLanguageHighlighterColors.KEYWORD);
+    public static final TextAttributesKey RESERVED_OP
+            = TextAttributesKey.createTextAttributesKey("HS_RESERVED_OP", DefaultLanguageHighlighterColors.PREDEFINED_SYMBOL);
+    public static final TextAttributesKey COMMA
+            = TextAttributesKey.createTextAttributesKey("HS_COMMA", DefaultLanguageHighlighterColors.COMMA);
+    public static final TextAttributesKey SEMICOLON
+            = TextAttributesKey.createTextAttributesKey("HS_SEMICOLON", DefaultLanguageHighlighterColors.SEMICOLON);
+    public static final TextAttributesKey BRACKETS
+            = TextAttributesKey.createTextAttributesKey("HS_BRACKETS", DefaultLanguageHighlighterColors.BRACKETS);
+    public static final TextAttributesKey PARENTHESES
+            = TextAttributesKey.createTextAttributesKey("HS_PARENTHESES", DefaultLanguageHighlighterColors.PARENTHESES);
+    public static final TextAttributesKey BRACES
+            = TextAttributesKey.createTextAttributesKey("HS_BRACES", DefaultLanguageHighlighterColors.BRACES);
+    public static final TextAttributesKey NESTED_COMMENT
+            = TextAttributesKey.createTextAttributesKey("HS_NESTED_COMMENT", DefaultLanguageHighlighterColors.BLOCK_COMMENT);
+    public static final TextAttributesKey HADDOCK
+            = TextAttributesKey.createTextAttributesKey("HS_HADDOCK", DefaultLanguageHighlighterColors.DOC_COMMENT);
+    public static final TextAttributesKey COMMENT
+            = TextAttributesKey.createTextAttributesKey("HS_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT);
+    public static final TextAttributesKey INTEGER
+            = TextAttributesKey.createTextAttributesKey("HS_INTEGER", DefaultLanguageHighlighterColors.NUMBER);
+    public static final TextAttributesKey FLOAT
+            = TextAttributesKey.createTextAttributesKey("HS_FLOAT", DefaultLanguageHighlighterColors.NUMBER);
+    public static final TextAttributesKey CHAR
+            = TextAttributesKey.createTextAttributesKey("HS_CHAR", DefaultLanguageHighlighterColors.NUMBER);
+    public static final TextAttributesKey CONID //Constructors, type constructors and type classes
+            = TextAttributesKey.createTextAttributesKey("HS_CONSTRUCTOR", DefaultLanguageHighlighterColors.INSTANCE_FIELD);
+    public static final TextAttributesKey VARID
+            = TextAttributesKey.createTextAttributesKey("HS_VARIABLE", DefaultLanguageHighlighterColors.FUNCTION_CALL);
+    public static final TextAttributesKey PARAMETER
+            = TextAttributesKey.createTextAttributesKey("HS_PARAMETER", DefaultLanguageHighlighterColors.PARAMETER);
+    public static final TextAttributesKey INFIXVARID
+            = TextAttributesKey.createTextAttributesKey("HS_INFIX_VARID", DefaultLanguageHighlighterColors.FUNCTION_CALL);
+    public static final TextAttributesKey VARSYM
+            = TextAttributesKey.createTextAttributesKey("HS_VARSYM", DefaultLanguageHighlighterColors.OPERATION_SIGN);
+    public static final TextAttributesKey CONSYM
+            = TextAttributesKey.createTextAttributesKey("HS_CONSYM", DefaultLanguageHighlighterColors.PREDEFINED_SYMBOL);
+    public static final TextAttributesKey PRAGMA
+            = TextAttributesKey.createTextAttributesKey("HS_PRAGMA", DefaultLanguageHighlighterColors.METADATA);
+    public static final TextAttributesKey STRING
+            = TextAttributesKey.createTextAttributesKey("HS_STRING", DefaultLanguageHighlighterColors.STRING);
+    public static final TextAttributesKey QUASIQUOTE
+            = TextAttributesKey.createTextAttributesKey("HS_QUASIQUOTE", DefaultLanguageHighlighterColors.STRING);
+    public static final TextAttributesKey ESCAPE
+            = TextAttributesKey.createTextAttributesKey("HS_ESCAPE", DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE);
+    public static final TextAttributesKey SIGNATURE =
+            TextAttributesKey.createTextAttributesKey("HS_SIGNATURE");
 
     private static final Map<IElementType, TextAttributesKey> keys;
 
@@ -58,12 +86,14 @@ public class HaskellSyntaxHighlighter extends SyntaxHighlighterBase {
     }
 
     static {
-        keys = new HashMap<IElementType, TextAttributesKey>(0);
-        keysPutEach(HaskellLanguage.RESERVED_IDS_TOKENS, RESERVEDID);
-        keysPutEach(HaskellLanguage.RESERVED_OPS_TOKENS, RESERVEDOP);
+        keys = new HashMap<>(0);
+        keysPutEach(HaskellLanguage.RESERVED_IDS_TOKENS, RESERVED_ID);
+        keysPutEach(HaskellLanguage.RESERVED_OPS_TOKENS, RESERVED_OP);
         keysPutEach(HaskellLanguage.BRACKET_TOKENS, BRACKETS);
+        keysPutEach(HaskellLanguage.PARENS_TOKENS, PARENTHESES);
+        keysPutEach(HaskellLanguage.BRACE_TOKENS, BRACES);
         keysPutEach(Arrays.asList(HaskellTypes.DOUBLEQUOTE, HaskellTypes.STRINGTOKEN), STRING);
-        keysPutEach(Arrays.asList(HaskellTypes.COMMENTTEXT, HaskellTypes.OPENCOM, HaskellTypes.CLOSECOM), NCOMMENT);
+        keysPutEach(Arrays.asList(HaskellTypes.COMMENTTEXT, HaskellTypes.OPENCOM, HaskellTypes.CLOSECOM), NESTED_COMMENT);
         keysPutEach(Arrays.asList(HaskellTypes.PRAGMA, HaskellTypes.OPENPRAGMA, HaskellTypes.CLOSEPRAGMA), PRAGMA);
         keys.put(HaskellTypes.COMMA, COMMA);
         keys.put(HaskellTypes.SEMICOLON, SEMICOLON);
@@ -75,7 +105,7 @@ public class HaskellSyntaxHighlighter extends SyntaxHighlighterBase {
         keys.put(HaskellTypes.CHARTOKEN, CHAR);
         keys.put(HaskellTypes.VARSYMTOK, VARSYM);
         keys.put(HaskellTypes.CONSYMTOK, CONSYM);
-        keys.put(HaskellTypes.QQTEXT, QQTEXT);
+        keys.put(HaskellTypes.QQTEXT, QUASIQUOTE);
         keys.put(HaskellTypes.INFIXVARID, INFIXVARID);
         keys.put(HaskellTypes.SHEBANGSTART, COMMENT);
         keys.put(HaskellTypes.SHEBANGPATH, COMMENT);

--- a/src/com/haskforce/language/HaskellNamesValidator.java
+++ b/src/com/haskforce/language/HaskellNamesValidator.java
@@ -15,12 +15,12 @@ public class HaskellNamesValidator implements NamesValidator {
      * Slight overapproximation of keywords, but they are keyword in some
      * Haskell variant.
      */
-    public static final HashSet<String> HASKELL_KEYWORDS = new HashSet<String>(
-            Arrays.asList(new String[]{"as", "case", "class", "data", "default"
+    public static final HashSet<String> HASKELL_KEYWORDS = new HashSet<>(
+            Arrays.asList("as", "case", "class", "data", "default"
                     , "deriving", "do", "else", "export", "forall", "foreign"
                     , "hiding", "if", "import", "in", "infix", "infixl", "infixr"
                     , "instance", "let", "module", "newtype", "of", "qualified"
-                    , "safe", "then", "type", "where"}));
+                    , "safe", "then", "type", "where"));
 
     /**
      * Checks if the specified string is a keyword in the language.

--- a/src/com/haskforce/settings/HaskellColorSettingsPage.java
+++ b/src/com/haskforce/settings/HaskellColorSettingsPage.java
@@ -18,25 +18,29 @@ import java.util.Map;
 public class HaskellColorSettingsPage implements ColorSettingsPage {
     private static final AttributesDescriptor[] DESCRIPTORS = new AttributesDescriptor[] {
             new AttributesDescriptor("Pragma", HaskellSyntaxHighlighter.PRAGMA),
-            new AttributesDescriptor("Reserved IDs", HaskellSyntaxHighlighter.RESERVEDID),
+            new AttributesDescriptor("Reserved IDs", HaskellSyntaxHighlighter.RESERVED_ID),
             new AttributesDescriptor("Constructor", HaskellSyntaxHighlighter.CONID),
             new AttributesDescriptor("Variable", HaskellSyntaxHighlighter.VARID),
             new AttributesDescriptor("Infix Function", HaskellSyntaxHighlighter.INFIXVARID),
             new AttributesDescriptor("Symbol", HaskellSyntaxHighlighter.VARSYM),
             new AttributesDescriptor("Cons Symbol", HaskellSyntaxHighlighter.CONSYM),
-            new AttributesDescriptor("Reserved Symbol", HaskellSyntaxHighlighter.RESERVEDOP),
+            new AttributesDescriptor("Reserved Symbol", HaskellSyntaxHighlighter.RESERVED_OP),
             new AttributesDescriptor("Comma", HaskellSyntaxHighlighter.COMMA),
             new AttributesDescriptor("Semicolon", HaskellSyntaxHighlighter.SEMICOLON),
             new AttributesDescriptor("Brackets", HaskellSyntaxHighlighter.BRACKETS),
+            new AttributesDescriptor("Parentheses", HaskellSyntaxHighlighter.PARENTHESES),
+            new AttributesDescriptor("Braces", HaskellSyntaxHighlighter.BRACES),
             new AttributesDescriptor("String", HaskellSyntaxHighlighter.STRING),
             new AttributesDescriptor("Integer", HaskellSyntaxHighlighter.INTEGER),
             new AttributesDescriptor("Float", HaskellSyntaxHighlighter.FLOAT),
             new AttributesDescriptor("Char", HaskellSyntaxHighlighter.CHAR),
             new AttributesDescriptor("Line Comment", HaskellSyntaxHighlighter.COMMENT),
-            new AttributesDescriptor("Block Comment", HaskellSyntaxHighlighter.NCOMMENT),
+            new AttributesDescriptor("Block Comment", HaskellSyntaxHighlighter.NESTED_COMMENT),
             new AttributesDescriptor("Doc Comment", HaskellSyntaxHighlighter.HADDOCK),
             new AttributesDescriptor("Escape", HaskellSyntaxHighlighter.ESCAPE),
-            new AttributesDescriptor("Quasi Quotes", HaskellSyntaxHighlighter.QQTEXT),
+            new AttributesDescriptor("Quasi Quotes", HaskellSyntaxHighlighter.QUASIQUOTE),
+            new AttributesDescriptor("Signature", HaskellSyntaxHighlighter.SIGNATURE),
+            new AttributesDescriptor("Parameter", HaskellSyntaxHighlighter.PARAMETER),
     };
 
     @Nullable
@@ -81,14 +85,14 @@ public class HaskellColorSettingsPage implements ColorSettingsPage {
                 "(<vs><~></vs>) <ro>=</ro> <vi>mzip</vi>\n" +
                 '\n' +
                 "<vi>bar</vi> <ro>::</ro> [<vi>a</vi>] <ro>-></ro> Int <ro>-></ro> <br>[</br><vi>a</vi><br>]</br>\n" +
-                "<vi>bar</vi> <vi>xs</vi> 0 <ro>=</ro> <br>[</br><br>]</br>\n" +
-                "<vi>bar</vi> <vi>xs</vi> <vi>n</vi> <ro>=</ro> <vi>xs</vi> <vs>++</vs> <br>(</br><vi>bar</vi> <vi>xs</vi> <br>(</br><vi>n</vi> <vs>-</vs> 1<br>)</br><br>)</br>\n" +
+                "<vi>bar</vi> <pa>xs</pa> 0 <ro>=</ro> <br>[</br><br>]</br>\n" +
+                "<vi>bar</vi> <pa>xs</pa> <pa>n</pa> <ro>=</ro> <vi>xs</vi> <vs>++</vs> <br>(</br><vi>bar</vi> <vi>xs</vi> <br>(</br><vi>n</vi> <vs>-</vs> 1<br>)</br><br>)</br>\n" +
                 '\n' +
-                "<vi>listToBool</vi> <ro>::</ro> <br>[</br><vi>a</vi><br>]</br> <ro>-></ro> Bool\n" +
+                "<si>listToBool</si> <ro>::</ro> <br>[</br><vi>a</vi><br>]</br> <ro>-></ro> Bool\n" +
                 "<vi>listToBool</vi> <br>[</br><br>]</br> <ro>=</ro> False\n" +
                 "<vi>listToBool</vi> <ri>_</ri> <ro>=</ro> True\n" +
                 '\n' +
-                "<vi>listToBool'</vi> <vi>xs</vi> <ro>=</ro> <ri>if</ri> <vi>length</vi> <vi>xs</vi> <vs>></vs> 0 <ri>then</ri> True <ri>else</ri> False\n" +
+                "<vi>listToBool'</vi> <pa>xs</pa> <ro>=</ro> <ri>if</ri> <vi>length</vi> <vi>xs</vi> <vs>></vs> 0 <ri>then</ri> True <ri>else</ri> False\n" +
                 '\n' +
                 "<vi>listToBool''</vi> <ro>=</ro> <vi>not</vi> <vs>.</vs> <vi>null</vi>\n" +
                 '\n' +
@@ -114,16 +118,18 @@ public class HaskellColorSettingsPage implements ColorSettingsPage {
     public Map<String, TextAttributesKey> getAdditionalHighlightingTagToDescriptorMap() {
         @NonNls
         final Map<String, TextAttributesKey> map = new THashMap<String, TextAttributesKey>();
-        map.put("ri", HaskellSyntaxHighlighter.RESERVEDID);
-        map.put("ro", HaskellSyntaxHighlighter.RESERVEDOP);
+        map.put("ri", HaskellSyntaxHighlighter.RESERVED_ID);
+        map.put("ro", HaskellSyntaxHighlighter.RESERVED_OP);
         map.put("vs", HaskellSyntaxHighlighter.VARSYM);
         map.put("cs", HaskellSyntaxHighlighter.CONSYM);
         map.put("vi", HaskellSyntaxHighlighter.VARID);
         map.put("iv", HaskellSyntaxHighlighter.INFIXVARID);
-        map.put("nc", HaskellSyntaxHighlighter.NCOMMENT);
+        map.put("nc", HaskellSyntaxHighlighter.NESTED_COMMENT);
         map.put("co", HaskellSyntaxHighlighter.COMMA);
         map.put("br", HaskellSyntaxHighlighter.BRACKETS);
-        map.put("qq", HaskellSyntaxHighlighter.QQTEXT);
+        map.put("qq", HaskellSyntaxHighlighter.QUASIQUOTE);
+        map.put("pa", HaskellSyntaxHighlighter.PARAMETER);
+        map.put("si", HaskellSyntaxHighlighter.SIGNATURE);
         return map;
     }
 


### PR DESCRIPTION
This pull request does two things:

1) Fix existing attributes so the colour can be properly changed for every attribute individually.
2) Add two more attributes (type signature and function parameters)

(Continuing from gitter: I've removed my custom colour scheme since I wasn't sure it worked with Darcula etc.)