### PR TITLE
Fix bug with hindent format action not working properly

### DIFF
--- a/src/com/haskforce/actions/HaskellHindentFormatAction.java
+++ b/src/com/haskforce/actions/HaskellHindentFormatAction.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 
-import org.apache.sanselan.util.IOUtils;
 import org.jetbrains.annotations.NotNull;
 
 import com.haskforce.psi.HaskellFile;
@@ -46,6 +45,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
@@ -107,7 +107,9 @@ public class HaskellHindentFormatAction extends AnAction implements DumbAware {
             // Pipe file into the process
             final InputStream fileContents = backingFile.getInputStream();
             final OutputStream processStdin = handler.getProcessInput();
-            IOUtils.copyStreamToStream(fileContents, processStdin);
+            FileUtil.copy(fileContents, processStdin);
+            fileContents.close();
+            processStdin.close();
 
             handler.addProcessListener(new CapturingProcessAdapter() {
                 @Override


### PR DESCRIPTION
* `org.apache.sanselan` package removed
    * [change notes](https://github.com/JetBrains/intellij-sdk-docs/blob/master/reference_guide/api_changes_list.md#changes-in-intellij-platform-20173)
    * [commit log](https://github.com/JetBrains/intellij-community/commit/e791557ca1489b02d178aa68960d645ab501e674)
* `org.apache.sanselan.util.IOUtils` restored for compatibility
    * [commit log](https://github.com/JetBrains/intellij-community/commit/54f22ff9520c33b023c6bdbe7fa6e58ce18a0b6b#diff-cafff5bebdc718cddb99a50f535734a7)
* Restored `org.apache.sanselan.util.IOUtils#copyStreamToStream` has a bug
    * Internally created streams are not closed
    * [original implementation]( https://github.com/apache/sanselan/blob/trunk/src/main/java/org/apache/commons/imaging/util/IoUtils.java#L172)