### PR TITLE
refs #415; Avoid forcing file save for external tools

### DIFF
--- a/src/com/haskforce/highlighting/annotation/external/HLintUtil.scala
+++ b/src/com/haskforce/highlighting/annotation/external/HLintUtil.scala
@@ -24,11 +24,11 @@ object HLintUtil {
   }
 
   def runHLintNumericVersion(
-    toolConsole: HaskellToolsConsole,
+    toolConsole: HaskellToolsConsole.Curried,
     workDir: String,
     hlintPath: String
   ): Either[ExecError, VersionTriple] = {
-    HLint.runHlint(toolConsole, workDir, hlintPath, "--numeric-version")
+    HLint.runHlint(toolConsole, workDir, hlintPath, "--numeric-version", null)
       .flatMap(parseVersion)
   }
 }

--- a/src/com/haskforce/highlighting/annotation/external/HaskellExternalAnnotator.scala
+++ b/src/com/haskforce/highlighting/annotation/external/HaskellExternalAnnotator.scala
@@ -1,6 +1,5 @@
 package com.haskforce.highlighting.annotation.external
 
-import com.haskforce.Implicits._
 import com.haskforce.highlighting.annotation.external.HaskellExternalAnnotator.State
 import com.haskforce.highlighting.annotation.{HaskellAnnotationHolder, HaskellProblem, Problems}
 import com.intellij.lang.annotation.{AnnotationHolder, ExternalAnnotator}
@@ -13,7 +12,8 @@ import org.jetbrains.annotations.{NotNull, Nullable}
 import scala.collection.JavaConverters._
 
 /** Single annotator that calls all external tools used for annotations. */
-class HaskellExternalAnnotator extends ExternalAnnotator[PsiFile, State] {
+class HaskellExternalAnnotator
+  extends ExternalAnnotator[HaskellExternalAnnotator.InitialInfo, State] {
 
   /**
    * The default implementation here is to not annotate files that have lexer/parser errors.
@@ -21,46 +21,51 @@ class HaskellExternalAnnotator extends ExternalAnnotator[PsiFile, State] {
    * appearing.  To get around this, we ignore the `hasErrors` argument.
    */
   @Nullable
-  override def collectInformation
-      (@NotNull file: PsiFile, @NotNull editor: Editor, hasErrors: Boolean): PsiFile = {
-    collectInformation(file)
-  }
+  override def collectInformation(
+    @NotNull file: PsiFile,
+    @NotNull editor: Editor,
+    hasErrors: Boolean
+  ): HaskellExternalAnnotator.InitialInfo = collectInformation(file)
 
   /** Simply returns the file so it will get passed to doAnnotate() */
   @NotNull
-  override def collectInformation(@NotNull file: PsiFile): PsiFile = {
-    file
+  override def collectInformation(
+    @NotNull file: PsiFile
+  ): HaskellExternalAnnotator.InitialInfo = {
+    val problemsProviders = HaskellExternalAnnotator.problemsProviderFactories.flatMap(_.get(file))
+    HaskellExternalAnnotator.InitialInfo(
+      file,
+      problemsProviders
+    )
   }
 
   /** Builds the set of annotations to be applied to the source file. */
   @Nullable
-  override def doAnnotate(@NotNull file: PsiFile): State = {
-    // We need to save the files so external processes will see what we see.
-    saveAllFiles()
+  override def doAnnotate(
+    @NotNull info: HaskellExternalAnnotator.InitialInfo
+  ): State = {
     // Constructs our annotation state for a file given our registered providers.
-    State.buildForFile(file)
+    State.create(info)
   }
 
   /** Applies the annotations from the State to the source file. */
-  override def apply
-      (@NotNull file: PsiFile, state: State, @NotNull holder: AnnotationHolder)
-      : Unit = {
+  override def apply(
+    @NotNull file: PsiFile,
+    state: State,
+    @NotNull holder: AnnotationHolder
+  ): Unit = {
     HaskellExternalAnnotator.createAnnotations(
       file, state.getProblems, new HaskellAnnotationHolder(holder)
-    )
-  }
-
-  private def saveAllFiles(): Unit = {
-    ApplicationManager.getApplication.invokeAndWait(
-      () => FileDocumentManager.getInstance.saveAllDocuments(),
-      // We cannot use ModalityState.any(); see issue #288
-      // https://github.com/carymrobbins/intellij-haskforce/issues/288#issuecomment-319835496
-      ModalityState.defaultModalityState()
     )
   }
 }
 
 object HaskellExternalAnnotator {
+
+  final case class InitialInfo(
+    psiFile: PsiFile,
+    problemsProviders: List[ProblemsProvider]
+  )
 
   /** Registered problem providers for our configured tools. */
   val problemsProviderFactories: List[ProblemsProviderFactory] = List(
@@ -69,11 +74,11 @@ object HaskellExternalAnnotator {
   )
 
   /** Helper to annotate problems in our source from external tools. */
-  def createAnnotations
-      (@NotNull file: PsiFile,
-       problems: Stream[HaskellProblem],
-       @NotNull holder: HaskellAnnotationHolder)
-      : Unit = {
+  def createAnnotations(
+    @NotNull file: PsiFile,
+    problems: Stream[HaskellProblem],
+    @NotNull holder: HaskellAnnotationHolder
+  ): Unit = {
     if (!file.isValid) return
     problems.foreach { _.createAnnotations(file, holder) }
   }
@@ -88,9 +93,8 @@ object HaskellExternalAnnotator {
   }
 
   object State {
-    /** Smart constructor which traverses our factories and obtains problem futures. */
-    def buildForFile(file: PsiFile): State = {
-      State(problemsProviderFactories.flatMap(_.get(file).map(_.getProblems)))
+    def create(info: InitialInfo): State = {
+      State(info.problemsProviders.map(_.getProblems))
     }
   }
 }

--- a/src/com/haskforce/highlighting/annotation/external/impl/GhcModiCompileProblemsProvider.scala
+++ b/src/com/haskforce/highlighting/annotation/external/impl/GhcModiCompileProblemsProvider.scala
@@ -1,37 +1,20 @@
 package com.haskforce.highlighting.annotation.external.impl
 
-import java.util.concurrent.Future
-
-import com.intellij.openapi.module.{Module, ModuleUtilCore}
-import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiFile
-
 import com.haskforce.highlighting.annotation.Problems
-import com.haskforce.highlighting.annotation.external.{ProblemsProvider, GhcModi}
-import com.haskforce.utils.WrappedFuture
+import com.haskforce.highlighting.annotation.external.{GhcModi, ProblemsProvider}
+import com.intellij.psi.PsiFile
 
 class GhcModiCompileProblemsProvider private(
   ghcModi: GhcModi,
-  filePath: String
+  psiFile: PsiFile
 ) extends ProblemsProvider {
 
   override def getProblems: Option[Problems] = {
-    Option(ghcModi.syncCheck(filePath))
+    Option(ghcModi.check(psiFile))
   }
 }
 
 object GhcModiCompileProblemsProvider {
-  def create(psiFile: PsiFile): Option[GhcModiCompileProblemsProvider] = for {
-    ghcModi <- GhcModi.get(psiFile)
-    filePath <- Option(psiFile.getVirtualFile.getCanonicalPath)
-  } yield new GhcModiCompileProblemsProvider(ghcModi, filePath)
-}
-
-final class GhcModiFutureProblems(
-  underlying: Future[Problems], project: Project
-) extends WrappedFuture[Option[Problems]] {
-
-  override def get: Option[Problems] = {
-    Option(GhcModi.getFuture(project, underlying))
-  }
+  def create(psiFile: PsiFile): Option[GhcModiCompileProblemsProvider] =
+    GhcModi.get(psiFile).map(new GhcModiCompileProblemsProvider(_, psiFile))
 }

--- a/src/com/haskforce/highlighting/annotation/external/impl/HLintProblemsProvider.scala
+++ b/src/com/haskforce/highlighting/annotation/external/impl/HLintProblemsProvider.scala
@@ -1,39 +1,35 @@
 package com.haskforce.highlighting.annotation.external.impl
 
-import java.util.concurrent.{ExecutionException, Executors, Future}
+import java.util.concurrent.{ExecutionException, Future}
 
-import com.intellij.notification.NotificationType
-import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiFile
 import com.haskforce.highlighting.annotation.Problems
 import com.haskforce.highlighting.annotation.external.{HLint, ProblemsProvider}
 import com.haskforce.psi.HaskellFile
 import com.haskforce.utils.{CastUtil, ExecUtil, NotificationUtil, WrappedFuture}
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
 
 class HLintProblemsProvider private(
   project: Project,
   workDir: String,
-  filePath: String,
   haskellFile: HaskellFile
 ) extends ProblemsProvider {
 
   override def getProblems: Option[Problems] = {
-    Option(HLint.lint(project, workDir, filePath, haskellFile))
+    Option(HLint.lint(project, workDir, haskellFile))
   }
 }
 
 object HLintProblemsProvider {
   def create(psiFile: PsiFile): Option[HLintProblemsProvider] = for {
     haskellFile <- CastUtil.down[HaskellFile](psiFile)
-    filePath <- Option(psiFile.getVirtualFile.getCanonicalPath)
     workDir = ExecUtil.guessWorkDir(psiFile)
     project = psiFile.getProject
-  } yield new HLintProblemsProvider(project, workDir, filePath, haskellFile)
+  } yield new HLintProblemsProvider(project, workDir, haskellFile)
 
-  val executorService = Executors.newSingleThreadExecutor()
-
-  val LOG = Logger.getInstance(classOf[HLintProblemsProvider])
+  val LOG: Logger = Logger.getInstance(classOf[HLintProblemsProvider])
 }
 
 class HLintFutureProblems(


### PR DESCRIPTION
Fixes #415 
Fixes #406

This should improve performance for external tool integrations as well. When using ghc-mod, we no longer need to wait for the file save and sync the file system before sending commands.