### PR TITLE
Retire Project components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version "0.4.15"
+    id "org.jetbrains.intellij" version "0.4.21"
 }
 
 version = file('version.txt').text.trim()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -459,7 +459,8 @@
     <langCodeStyleSettingsProvider
         implementation="com.haskforce.language.formatting.HaskellLanguageCodeStyleSettingsProvider"/>
     <highlightErrorFilter implementation="com.haskforce.codeInsight.highlighting.HaskellHighlightErrorFilter"/>
-
+    <!-- Cache-->
+    <projectService serviceImplementation="com.haskforce.codeInsight.HaskellCompletionCacheService"/>
     <!-- Eta support -->
     <moduleType id="ETLAS_MODULE" implementationClass="com.haskforce.eta.project.module.EtlasModuleType"/>
     <projectConfigurable instance="com.haskforce.eta.settings.EtaCompilerConfigurable"

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -433,7 +433,7 @@
 
   <extensions defaultExtensionNs="com.intellij">
      <!-- ApplicationInitializedListener  -->
-      <applicationInitializedListener implementation="com.haskforce.internal.HaskForceInternal"/>
+      <applicationInitializedListener implementation="com.haskforce.ide.HaskForceInitializedListener"/>
     <!-- Haskell support -->
     <projectTemplatesFactory implementation="com.haskforce.haskell.project.template.HaskellProjectTemplatesFactory"/>
     <internalFileTemplate name="Haskell Module"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -432,7 +432,6 @@
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">
-     <!-- ApplicationInitializedListener  -->
       <applicationInitializedListener implementation="com.haskforce.ide.HaskForceInitializedListener"/>
     <!-- Haskell support -->
     <projectTemplatesFactory implementation="com.haskforce.haskell.project.template.HaskellProjectTemplatesFactory"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -388,14 +388,6 @@
     <!-- Add your application components here -->
   </application-components>
 
-  <project-components>
-    <component>
-      <implementation-class>
-        com.haskforce.codeInsight.HaskellCompletionCacheLoader
-      </implementation-class>
-    </component>
-  </project-components>
-
   <actions>
     <action id="Haskell.NewHaskellFile" class="com.haskforce.actions.CreateHaskellFileAction"
             text="Haskell File" description="Create new Haskell file">
@@ -440,6 +432,8 @@
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">
+     <!-- ApplicationInitializedListener  -->
+      <applicationInitializedListener implementation="com.haskforce.internal.HaskForceInternal"/>
     <!-- Haskell support -->
     <projectTemplatesFactory implementation="com.haskforce.haskell.project.template.HaskellProjectTemplatesFactory"/>
     <internalFileTemplate name="Haskell Module"/>

--- a/src/com/haskforce/cabal/highlighting/CabalAnnotator.scala
+++ b/src/com/haskforce/cabal/highlighting/CabalAnnotator.scala
@@ -1,10 +1,10 @@
 package com.haskforce.cabal.highlighting
 
+import com.haskforce.cabal.lang.psi.CabalTypes._
+import com.haskforce.cabal.lang.psi._
 import com.intellij.lang.annotation.{AnnotationHolder, Annotator, HighlightSeverity}
 import com.intellij.openapi.editor.colors.{EditorColorsManager, TextAttributesKey}
 import com.intellij.psi.PsiElement
-import com.haskforce.cabal.lang.psi._
-import com.haskforce.cabal.lang.psi.CabalTypes._
 
 class CabalAnnotator extends Annotator {
 
@@ -18,8 +18,9 @@ class CabalAnnotator extends Annotator {
     }
   }
 
-  private def setHighlighting(element: PsiElement, holder: AnnotationHolder, key: TextAttributesKey) {
+  private def setHighlighting(element: PsiElement, holder: AnnotationHolder, key: TextAttributesKey): Unit = {
     holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
       .enforcedTextAttributes(EditorColorsManager.getInstance.getGlobalScheme.getAttributes(key))
+    ()
   }
 }

--- a/src/com/haskforce/cabal/highlighting/CabalAnnotator.scala
+++ b/src/com/haskforce/cabal/highlighting/CabalAnnotator.scala
@@ -1,6 +1,6 @@
 package com.haskforce.cabal.highlighting
 
-import com.intellij.lang.annotation.{AnnotationHolder, Annotator, HighlightSeverity}
+import com.intellij.lang.annotation.{AnnotationHolder, Annotator}
 import com.intellij.openapi.editor.colors.{EditorColorsManager, TextAttributesKey}
 import com.intellij.psi.PsiElement
 import com.haskforce.cabal.lang.psi._
@@ -20,8 +20,7 @@ class CabalAnnotator extends Annotator {
 
   private def setHighlighting(element: PsiElement, holder: AnnotationHolder, key: TextAttributesKey) {
     holder
-      .newSilentAnnotation(HighlightSeverity.INFORMATION)
-      .enforcedTextAttributes(EditorColorsManager.getInstance.getGlobalScheme.getAttributes(key))
-      .create()
+        .createWeakWarningAnnotation(element, "Message")
+      .setEnforcedTextAttributes(EditorColorsManager.getInstance.getGlobalScheme.getAttributes(key))
   }
 }

--- a/src/com/haskforce/cabal/highlighting/CabalAnnotator.scala
+++ b/src/com/haskforce/cabal/highlighting/CabalAnnotator.scala
@@ -1,6 +1,6 @@
 package com.haskforce.cabal.highlighting
 
-import com.intellij.lang.annotation.{AnnotationHolder, Annotator}
+import com.intellij.lang.annotation.{AnnotationHolder, Annotator, HighlightSeverity}
 import com.intellij.openapi.editor.colors.{EditorColorsManager, TextAttributesKey}
 import com.intellij.psi.PsiElement
 import com.haskforce.cabal.lang.psi._
@@ -19,8 +19,7 @@ class CabalAnnotator extends Annotator {
   }
 
   private def setHighlighting(element: PsiElement, holder: AnnotationHolder, key: TextAttributesKey) {
-    holder
-        .createWeakWarningAnnotation(element, "Message")
-      .setEnforcedTextAttributes(EditorColorsManager.getInstance.getGlobalScheme.getAttributes(key))
+    holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+      .enforcedTextAttributes(EditorColorsManager.getInstance.getGlobalScheme.getAttributes(key))
   }
 }

--- a/src/com/haskforce/cabal/highlighting/CabalAnnotator.scala
+++ b/src/com/haskforce/cabal/highlighting/CabalAnnotator.scala
@@ -21,6 +21,6 @@ class CabalAnnotator extends Annotator {
   private def setHighlighting(element: PsiElement, holder: AnnotationHolder, key: TextAttributesKey): Unit = {
     holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
       .enforcedTextAttributes(EditorColorsManager.getInstance.getGlobalScheme.getAttributes(key))
-    ()
+      .create()
   }
 }

--- a/src/com/haskforce/codeInsight/HaskellCompletionCacheLoader.scala
+++ b/src/com/haskforce/codeInsight/HaskellCompletionCacheLoader.scala
@@ -2,17 +2,15 @@ package com.haskforce.codeInsight
 
 import java.util
 
-import com.haskforce.codeInsight.HaskellCompletionCacheLoader.LookupElementWrapper
-import com.haskforce.psi.{HaskellFile, HaskellPsiUtil}
+import com.haskforce.psi.HaskellFile
 import com.intellij.AppTopics
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor._
 import com.intellij.openapi.project.{Project, ProjectManagerListener}
-import com.intellij.openapi.util.Computable
 import com.intellij.openapi.vfs._
-import com.intellij.psi.{PsiFile, PsiManager}
+import com.intellij.psi.PsiManager
 
 import scala.annotation.tailrec
 
@@ -23,17 +21,14 @@ class HaskellCompletionCacheLoader extends ProjectManagerListener {
     project.getMessageBus.connect().subscribe(AppTopics.FILE_DOCUMENT_SYNC, new MyHandler(project))
   }
 
-  val cache = new HaskellCompletionCacheLoader.Cache()
-
-
-  class MyHandler(project : Project) extends FileDocumentManagerListener {
+  class MyHandler(project: Project) extends FileDocumentManagerListener {
     override def fileContentLoaded(file: VirtualFile, document: Document): Unit = {
       val app = ApplicationManager.getApplication
       app.runReadAction({ () =>
         Option(PsiManager.getInstance(project).findFile(file)).foreach {
           case psiFile: HaskellFile =>
             app.invokeLater({ () =>
-              updateCache(psiFile, force = false)
+              HaskellCompletionCacheLoader.get(project).updateCache(psiFile, force = false)
             }: Runnable)
           case _ => // noop
         }
@@ -41,65 +36,12 @@ class HaskellCompletionCacheLoader extends ProjectManagerListener {
     }
   }
 
-  def forceUpdateCache(file: PsiFile): Unit = updateCache(file, force = true)
-
-  def updateCache(file: PsiFile, force: Boolean): Unit = {
-    ApplicationManager.getApplication.executeOnPooledThread({ () =>
-      if (force || cache.ghcFlags.isEmpty) {
-        CompilerFlagsProviderFactory.get(file).foreach { provider =>
-          putStrings(cache.ghcFlags, provider.getFlags)
-        }
-      }
-      if (force || cache.visibleModules.isEmpty) {
-        VisibleModulesProviderFactory.get(file).foreach { provider =>
-          putStrings(cache.visibleModules, provider.getVisibleModules)
-        }
-      }
-      if (force || cache.languageExtensions.isEmpty) {
-        LanguageExtensionsProviderFactory.get(file).foreach { provider =>
-          putWrappers(cache.languageExtensions, provider.getLanguages)
-        }
-      }
-      if (force || cache.moduleSymbols.isEmpty) {
-        updateModuleSymbols(file)
-      }
-    }: Runnable)
-    ()
-  }
-
-  private def putWrappers(s: util.Set[LookupElementWrapper], xs: Array[String]) = {
-    util.Collections.addAll[LookupElementWrapper](s, xs.map(LookupElementWrapper.fromString): _*)
-  }
-
-  private def putStrings(s: util.Set[String], xs: Array[String]) = {
-    util.Collections.addAll[String](s, xs: _*)
-  }
-
-  private def updateModuleSymbols(file: PsiFile): Unit = {
-    ModuleSymbolsProviderFactory.get(file).foreach { provider =>
-      val imports = ApplicationManager.getApplication.runReadAction({ () =>
-        HaskellPsiUtil.parseImports(file)
-      }: Computable[util.List[HaskellPsiUtil.Import]])
-      imports.forEach { imp =>
-        val syms = provider.getSymbols(imp.module)
-        val symSet = new util.HashSet[LookupElementWrapper](
-          util.Arrays.asList(syms.map(
-            b => new LookupElementWrapper(b.toLookupElement)
-          ): _*)
-        )
-        Option(cache.moduleSymbols.get(imp.module)) match {
-          case None => cache.moduleSymbols.put(imp.module, symSet)
-          case Some(currentSymList) => currentSymList.addAll(symSet)
-        }
-        ()
-      }
-    }
-  }
 }
 
 object HaskellCompletionCacheLoader {
-  def get(project: Project): HaskellCompletionCacheLoader = {
-    project.getComponent(classOf[HaskellCompletionCacheLoader])
+
+  def get(project: Project): HaskellCompletionCacheService = {
+    project.getService(classOf[HaskellCompletionCacheService])
   }
 
   final class Cache {
@@ -129,4 +71,5 @@ object HaskellCompletionCacheLoader {
       new LookupElementWrapper(LookupElementUtil.fromString(s))
     }
   }
+
 }

--- a/src/com/haskforce/codeInsight/HaskellCompletionCacheService.scala
+++ b/src/com/haskforce/codeInsight/HaskellCompletionCacheService.scala
@@ -1,0 +1,73 @@
+package com.haskforce.codeInsight
+
+import java.util
+
+import com.haskforce.codeInsight.HaskellCompletionCacheLoader.LookupElementWrapper
+import com.haskforce.psi.HaskellPsiUtil
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.util.Computable
+import com.intellij.psi.PsiFile
+
+/**
+ * project-service that manages the cache
+ */
+class HaskellCompletionCacheService {
+
+  val cache = new HaskellCompletionCacheLoader.Cache()
+
+  def forceUpdateCache(file: PsiFile): Unit = updateCache(file, force = true)
+
+
+  def updateCache(file: PsiFile, force: Boolean): Unit = {
+    ApplicationManager.getApplication.executeOnPooledThread({ () =>
+      if (force || cache.ghcFlags.isEmpty) {
+        CompilerFlagsProviderFactory.get(file).foreach { provider =>
+          putStrings(cache.ghcFlags, provider.getFlags)
+        }
+      }
+      if (force || cache.visibleModules.isEmpty) {
+        VisibleModulesProviderFactory.get(file).foreach { provider =>
+          putStrings(cache.visibleModules, provider.getVisibleModules)
+        }
+      }
+      if (force || cache.languageExtensions.isEmpty) {
+        LanguageExtensionsProviderFactory.get(file).foreach { provider =>
+          putWrappers(cache.languageExtensions, provider.getLanguages)
+        }
+      }
+      if (force || cache.moduleSymbols.isEmpty) {
+        updateModuleSymbols(file)
+      }
+    }: Runnable)
+    ()
+  }
+
+  private def putWrappers(s: util.Set[LookupElementWrapper], xs: Array[String]) = {
+    util.Collections.addAll[LookupElementWrapper](s, xs.map(LookupElementWrapper.fromString): _*)
+  }
+
+  private def putStrings(s: util.Set[String], xs: Array[String]) = {
+    util.Collections.addAll[String](s, xs: _*)
+  }
+
+  private def updateModuleSymbols(file: PsiFile): Unit = {
+    ModuleSymbolsProviderFactory.get(file).foreach { provider =>
+      val imports = ApplicationManager.getApplication.runReadAction({ () =>
+        HaskellPsiUtil.parseImports(file)
+      }: Computable[util.List[HaskellPsiUtil.Import]])
+      imports.forEach { imp =>
+        val syms = provider.getSymbols(imp.module)
+        val symSet = new util.HashSet[LookupElementWrapper](
+          util.Arrays.asList(syms.map(
+            b => new LookupElementWrapper(b.toLookupElement)
+          ): _*)
+        )
+        Option(cache.moduleSymbols.get(imp.module)) match {
+          case None => cache.moduleSymbols.put(imp.module, symSet)
+          case Some(currentSymList) => currentSymList.addAll(symSet)
+        }
+        ()
+      }
+    }
+  }
+}

--- a/src/com/haskforce/ide/HaskForceInitializedListener.scala
+++ b/src/com/haskforce/ide/HaskForceInitializedListener.scala
@@ -1,4 +1,4 @@
-package com.haskforce.internal
+package com.haskforce.ide
 
 import com.haskforce.codeInsight.HaskellCompletionCacheLoader
 import com.intellij.ide.ApplicationInitializedListener
@@ -6,7 +6,7 @@ import com.intellij.openapi.application.{Application, ApplicationManager}
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.util.messages.Topic
 
-class HaskForceInternal extends ApplicationInitializedListener {
+class HaskForceInitializedListener extends ApplicationInitializedListener {
   override def componentsInitialized(): Unit = {
     val app = ApplicationManager.getApplication()
     registerTopic(app, ProjectManager.TOPIC, new HaskellCompletionCacheLoader)

--- a/src/com/haskforce/internal/HaskForceInternal.scala
+++ b/src/com/haskforce/internal/HaskForceInternal.scala
@@ -1,0 +1,20 @@
+package com.haskforce.internal
+
+import com.haskforce.codeInsight.HaskellCompletionCacheLoader
+import com.intellij.ide.ApplicationInitializedListener
+import com.intellij.openapi.application.{Application, ApplicationManager}
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.util.messages.Topic
+
+class HaskForceInternal extends ApplicationInitializedListener {
+  override def componentsInitialized(): Unit = {
+    val app = ApplicationManager.getApplication()
+    registerTopic(app, ProjectManager.TOPIC, new HaskellCompletionCacheLoader)
+  }
+
+  def registerTopic[A](app: Application, topic: Topic[A], instance: A): Unit = {
+    app.getMessageBus.connect(app).subscribe(topic, instance)
+  }
+}
+
+


### PR DESCRIPTION
Project components as-is are deprecated in IntelliJ. 
Depending on their usage they fall in different migrating categories. 

The behavior of the CacheLoader suggests a Listener as it does nothing up to the life cycle phase,  where the Ide spins up a Haskell project. 
The listener also enjoys the advantage to be disposed automatically.