### PR TITLE
Stop displaying the 'Type info not found' message

### DIFF
--- a/src/com/haskforce/actions/TypeInfoAction.java
+++ b/src/com/haskforce/actions/TypeInfoAction.java
@@ -45,7 +45,6 @@ public class TypeInfoAction extends AnAction {
         FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
         String typeInfo = TypeInfoUtil.getTypeInfo(project);
         if (typeInfo == null) {
-            // TODO: getTypeInfo should probably be @NotNull
             return;
         }
         JComponent label = HintUtil.createInformationLabel(typeInfo);

--- a/src/com/haskforce/highlighting/annotation/HaskellDocumentationProvider.java
+++ b/src/com/haskforce/highlighting/annotation/HaskellDocumentationProvider.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
  */
 
 public class HaskellDocumentationProvider extends AbstractDocumentationProvider {
+    @Nullable
     @Override
     public String generateDoc(PsiElement element, @Nullable PsiElement originalElement) {
         int startOffset = element.getTextRange().getStartOffset();

--- a/src/com/haskforce/highlighting/annotation/external/GhcMod.java
+++ b/src/com/haskforce/highlighting/annotation/external/GhcMod.java
@@ -254,7 +254,7 @@ public class GhcMod {
                               VisualPosition startPosition, @NotNull VisualPosition stopPosition) {
         final String stdout = simpleExec(module, workDir, getFlags(module.getProject()), "type" , canonicalPath,
                 String.valueOf(startPosition.line), String.valueOf(startPosition.column));
-        if (stdout == null) return "Type info not found";
+        if (stdout == null) return null;
         try {
             return GhcModUtil.handleTypeInfo(startPosition, stopPosition, stdout);
         } catch (GhcModUtil.TypeInfoParseException e) {

--- a/src/com/haskforce/highlighting/annotation/external/GhcModi.java
+++ b/src/com/haskforce/highlighting/annotation/external/GhcModi.java
@@ -216,7 +216,7 @@ public class GhcModi implements ModuleComponent, SettingsChangeNotifier {
                 final String command = "type " + canonicalPath + ' ' + startPosition.line + ' ' + startPosition.column;
                 final String stdout = simpleExec(command);
                 try {
-                    return stdout == null ? "Type info not found" : GhcModUtil.handleTypeInfo(startPosition, stopPosition, stdout);
+                    return stdout == null ? null : GhcModUtil.handleTypeInfo(startPosition, stopPosition, stdout);
                 } catch (GhcModUtil.TypeInfoParseException e) {
                     NotificationUtil.displayToolsNotification(
                       NotificationType.ERROR, module.getProject(), "Type Info Error",

--- a/src/com/haskforce/highlighting/annotation/external/TypeInfoUtil.java
+++ b/src/com/haskforce/highlighting/annotation/external/TypeInfoUtil.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiUtilBase;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This class will return the type info of the type under cursor or the selection. It seems to be necessary
@@ -23,6 +24,7 @@ import com.intellij.psi.util.PsiUtilBase;
  * it will report the error encountered instead of the type info.
  */
 public class TypeInfoUtil {
+    @Nullable
     public static String getTypeInfo(Project project) {
         FileEditorManager fileEditorManager = FileEditorManager.getInstance(
                 project);
@@ -53,10 +55,11 @@ public class TypeInfoUtil {
         return getTypeInfo(module, blockStart, blockEnd, projectFile);
     }
 
+    @Nullable
     public static String getTypeInfo(Module module, VisualPosition blockStart, VisualPosition blockEnd, VirtualFile projectFile) {
         final String canonicalPath = projectFile.getCanonicalPath();
         if (canonicalPath == null){
-            return "canonical path is null";
+            return null;
         }
         final String workDir = ExecUtil.guessWorkDir(module);
         if (ToolKey.GHC_MODI_KEY.getPath(module.getProject()) != null) {
@@ -66,7 +69,7 @@ public class TypeInfoUtil {
                         blockStart, blockEnd));
 
             } else {
-                return "ghcModi is not configured";
+                return null;
             }
         } else {
             return GhcMod.type(module, workDir, canonicalPath, blockStart, blockEnd);


### PR DESCRIPTION
It's not really useful and shows up everywhere due to the quick documentation. Instead, we'll just not display the message if type info is not found. There's probably a better UI for this in the case where the external tool fails to legitimately provide type info in some circumstance, but we can tackle that when it becomes a little more obvious what that UI should be.