### PR TITLE
IDEA 2021.1 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
     apply plugin: 'org.jetbrains.intellij'
 
     intellij {
-        version = '2020.3'
+        version = '2021.1'
         pluginName = 'HaskForce'
         plugins = ['java', 'yaml']
     }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -20,7 +20,7 @@
     <p>
       <b>v0.3.46</b>
       <ul>
-        <li></li>
+        <li>IDEA 2021.1 Support (requires Java 11)</li>
       </ul>
       <b>v0.3.45</b>
       <ul>


### PR DESCRIPTION
Note that this version needs to be built with Java 11.